### PR TITLE
ISPN-8024 Preview Hibernate cache local tutorial

### DIFF
--- a/hibernate-cache-local/pom.xml
+++ b/hibernate-cache-local/pom.xml
@@ -14,6 +14,7 @@
    <properties>
       <version.hibernate-core>5.2.7.Final</version.hibernate-core>
       <version.h2>1.3.176</version.h2>
+      <version.log4j>2.8.1</version.log4j>
    </properties>
 
    <build>
@@ -58,6 +59,11 @@
          <groupId>com.h2database</groupId>
          <artifactId>h2</artifactId>
          <version>${version.h2}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.logging.log4j</groupId>
+         <artifactId>log4j-core</artifactId>
+         <version>${version.log4j}</version>
       </dependency>
    </dependencies>
 </project>

--- a/hibernate-cache-local/pom.xml
+++ b/hibernate-cache-local/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+   <artifactId>infinispan-simple-tutorials-hibernate-cache-local</artifactId>
+   <parent>
+      <relativePath>../pom.xml</relativePath>
+      <version>1.0.0-SNAPSHOT</version>
+      <groupId>org.infinispan.tutorial.simple</groupId>
+      <artifactId>infinispan-simple-tutorials</artifactId>
+   </parent>
+   <name>Infinispan Simple Tutorials: Hibernate Cache Local</name>
+
+   <properties>
+      <version.hibernate-core>5.2.7.Final</version.hibernate-core>
+      <version.h2>1.3.176</version.h2>
+   </properties>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <goals>
+                     <goal>exec</goal>
+                  </goals>
+               </execution>
+            </executions>
+            <configuration>
+               <executable>java</executable>
+               <arguments>
+                  <argument>-Djava.net.preferIPv4Stack=true</argument>
+                  <argument>-Djava.util.logging.config.file=src/main/resources/logging.properties</argument>
+                  <argument>-classpath</argument>
+                  <classpath />
+                  <argument>org.infinispan.tutorial.simple.hibernate.cache.local.InfinispanHibernateCacheLocal</argument>
+               </arguments>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.hibernate</groupId>
+         <artifactId>hibernate-core</artifactId>
+         <version>${version.hibernate-core}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-hibernate-cache</artifactId>
+         <!-- TODO: Version should not be defined, should come from bom (ISPN-8032) -->
+         <version>${version.infinispan}</version>
+      </dependency>
+      <dependency>
+         <groupId>com.h2database</groupId>
+         <artifactId>h2</artifactId>
+         <version>${version.h2}</version>
+      </dependency>
+   </dependencies>
+</project>

--- a/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
+++ b/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
@@ -1,0 +1,260 @@
+package org.infinispan.tutorial.simple.hibernate.cache.local;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+import javax.persistence.Persistence;
+import javax.persistence.TypedQuery;
+
+import org.hibernate.Session;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.hibernate.stat.Statistics;
+import org.infinispan.tutorial.simple.hibernate.cache.local.model.Event;
+import org.infinispan.tutorial.simple.hibernate.cache.local.model.Person;
+
+/**
+ * Example on how to use Infinispan as Hibernate cache provider
+ * in a standalone, single-node, environment.
+ *
+ * This example assumes that the JPA persistence configuration file
+ * is present in the default lookup location: META-INF/persistence.xml
+ *
+ * Run with these properties to hide Hibernate messages:
+ * -Djava.util.logging.config.file=src/main/resources/logging-app.properties
+ */
+public class InfinispanHibernateCacheLocal {
+
+   public static void main(String[] args) throws Exception {
+      // Create JPA persistence manager
+      EntityManagerFactory emf = Persistence.createEntityManagerFactory("events");
+
+      // Persist 3 entities, stats should show 3 second level cache puts
+      SecondLevelCacheStatistics cacheStats = persistEntities(emf);
+      System.out.printf("Event entity cache puts: %d (expected 3)%n", cacheStats.getPutCount());
+
+      // Find one of the persisted entities, stats should show a cache hit
+      cacheStats = findEntity(emf);
+      System.out.printf("Event entity cache hits: %d (expected 1)%n", cacheStats.getHitCount());
+
+      // Update one of the persisted entities, stats should show a cache hit and a cache put
+      cacheStats = updateEntity(1L, emf);
+      System.out.printf("Event entity cache hits: %d (expected 2)%n", cacheStats.getHitCount());
+      System.out.printf("Event entity cache puts: %d (expected 4)%n", cacheStats.getPutCount());
+
+      // Find the updated entity, stats should show a cache hit
+      cacheStats = findEntity(emf);
+      System.out.printf("Event entity cache hits: %d (expected 3)%n", cacheStats.getHitCount());
+
+
+      // Evict entity from cache
+      evictEntity(emf);
+
+      // Reload evicted entity, should come from DB
+      // Stats should show a cache miss and a cache put
+      cacheStats = findEntity(emf);
+      System.out.printf("Event entity cache miss: %d (expected 1)%n", cacheStats.getMissCount());
+      System.out.printf("Event entity cache puts: %d (expected 5)%n", cacheStats.getPutCount());
+
+      // Remove cached entity, stats shoudl show a cache hit
+      cacheStats = deleteEntity(emf);
+      System.out.printf("Event entity cache hits: %d (expected 4)%n", cacheStats.getHitCount());
+
+
+      // Query entities, expect:
+      // * no cache hits since query is not cached
+      // * a query cache miss and query cache put
+      Statistics stats = queryEntities(emf);
+      System.out.printf("Query cache miss: %d (expected 1)%n", stats.getQueryCacheMissCount());
+      System.out.printf("Query cache put: %d (expected 1)%n", stats.getQueryCachePutCount());
+
+      // Repeat query, expect:
+      // * two cache hits for the number of entities in cache
+      // * a query cache hit
+      stats = queryEntities(emf);
+      System.out.printf("Event entity cache hits: %d (expected 6)%n", stats.getSecondLevelCacheHitCount());
+      System.out.printf("Query cache hit: %d (expected 1)%n", stats.getQueryCacheHitCount());
+
+      // Update one of the persisted entities, stats should show a cache hit and a cache put
+      cacheStats = updateEntity(2L, emf);
+      System.out.printf("Event entity cache hits: %d (expected 7)%n", cacheStats.getHitCount());
+      System.out.printf("Event entity cache puts: %d (expected 6)%n", cacheStats.getPutCount());
+
+      // Repeat query after update, expect:
+      // * no cache hits or puts since entities are already cached
+      // * a query cache miss and query cache put, because when an entity is updated,
+      //   any queries for that type are invalidated
+      stats = queryEntities(emf);
+      System.out.printf("Query cache miss: %d (expected 2)%n", stats.getQueryCacheMissCount());
+      System.out.printf("Query cache put: %d (expected 2)%n", stats.getQueryCachePutCount());
+
+
+      // Save cache-expiring entity, stats should show a second level cache put
+      cacheStats = saveExpiringEntity(emf);
+      System.out.printf("Person entity cache puts: %d (expected 1)%n", cacheStats.getPutCount());
+
+      // Find expiring entity, stats should show a second level cache hit
+      cacheStats = findExpiringEntity(emf);
+      System.out.printf("Person entity cache hits: %d (expected 1)%n", cacheStats.getHitCount());
+
+      // Wait long enough for entity to be expired from cache
+      Thread.sleep(1100);
+
+      // Find expiring entity, after expiration entity should come from DB
+      // Stats should show a cache miss and a cache put
+      cacheStats = findExpiringEntity(emf);
+      System.out.printf("Person entity cache miss: %d (expected 1)%n", cacheStats.getMissCount());
+      System.out.printf("Person entity cache put: %d (expected 2)%n", cacheStats.getPutCount());
+
+      // Close persistence manager
+      emf.close();
+   }
+
+   private static SecondLevelCacheStatistics persistEntities(EntityManagerFactory emf) {
+      EntityManager em = emf.createEntityManager();
+      EntityTransaction tx = em.getTransaction();
+      try {
+         tx.begin();
+
+         em.persist(new Event("Caught a pokemon!"));
+         em.persist(new Event("Hatched an egg"));
+         em.persist(new Event("Became a gym leader"));
+
+         return getCacheStatistics(Event.class.getName(), em);
+      } catch (Throwable t) {
+         tx.setRollbackOnly();
+         throw t;
+      } finally {
+         if (tx.isActive()) tx.commit();
+         else tx.rollback();
+
+         em.close();
+      }
+   }
+
+   private static SecondLevelCacheStatistics findEntity(EntityManagerFactory emf) {
+      EntityManager em = emf.createEntityManager();
+      try {
+         Event event = em.find(Event.class, 1L);
+         System.out.printf("Found entity: %s%n", event);
+
+         return getCacheStatistics(Event.class.getName(), em);
+      } finally {
+         em.close();
+      }
+   }
+
+   private static SecondLevelCacheStatistics updateEntity(long id, EntityManagerFactory emf) {
+      EntityManager em = emf.createEntityManager();
+      EntityTransaction tx = em.getTransaction();
+      try {
+         tx.begin();
+
+         Event event = em.find(Event.class, id);
+         String newName = "Caught a Snorlax!!";
+         event.setName("Caught a Snorlax!!");
+
+         return getCacheStatistics(Event.class.getName(), em);
+      } catch (Throwable t) {
+         tx.setRollbackOnly();
+         throw t;
+      } finally {
+         if (tx.isActive()) tx.commit();
+         else tx.rollback();
+
+         em.close();
+      }
+   }
+
+   private static void evictEntity(EntityManagerFactory emf) {
+      EntityManager em = emf.createEntityManager();
+      try {
+         em.getEntityManagerFactory().getCache().evict(Event.class, 1L);
+      } finally {
+         em.close();
+      }
+   }
+
+   private static SecondLevelCacheStatistics deleteEntity(EntityManagerFactory emf) {
+      EntityManager em = emf.createEntityManager();
+      EntityTransaction tx = em.getTransaction();
+      try {
+         tx.begin();
+
+         Event event = em.find(Event.class, 1L);
+         em.remove(event);
+
+         return getCacheStatistics(Event.class.getName(), em);
+      } catch (Throwable t) {
+         tx.setRollbackOnly();
+         throw t;
+      } finally {
+         if (tx.isActive()) tx.commit();
+         else tx.rollback();
+
+         em.close();
+      }
+   }
+
+   private static Statistics queryEntities(EntityManagerFactory emf) {
+      EntityManager em = emf.createEntityManager();
+      try {
+         TypedQuery<Event> query = em.createQuery("from Event", Event.class);
+         query.setHint("org.hibernate.cacheable", Boolean.TRUE);
+         List<Event> events = query.getResultList();
+         System.out.printf("Queried events: %s%n", events);
+
+         return getStatistics(em);
+      } finally {
+         em.close();
+      }
+   }
+
+   private static SecondLevelCacheStatistics saveExpiringEntity(EntityManagerFactory emf) {
+      EntityManager em = emf.createEntityManager();
+      EntityTransaction tx = em.getTransaction();
+      try {
+         tx.begin();
+
+         em.persist(new Person("Satoshi"));
+
+         return getCacheStatistics(Person.class.getName(), em);
+      } catch (Throwable t) {
+         tx.setRollbackOnly();
+         throw t;
+      } finally {
+         if (tx.isActive()) tx.commit();
+         else tx.rollback();
+
+         em.close();
+      }
+   }
+
+   private static SecondLevelCacheStatistics findExpiringEntity(EntityManagerFactory emf) {
+      EntityManager em = emf.createEntityManager();
+      try {
+         Person person = em.find(Person.class, 4L);
+         System.out.printf("Found expiring entity: %s%n", person);
+
+         return getCacheStatistics(Person.class.getName(), em);
+      } finally {
+         em.close();
+      }
+   }
+
+   private static SecondLevelCacheStatistics getCacheStatistics(
+         String regionName, EntityManager em) {
+      return ((Session) em.getDelegate())
+            .getSessionFactory()
+            .getStatistics()
+            .getSecondLevelCacheStatistics(regionName);
+   }
+
+   private static Statistics getStatistics(EntityManager em) {
+      return ((Session) em.getDelegate())
+            .getSessionFactory()
+            .getStatistics();
+   }
+
+}

--- a/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
+++ b/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
@@ -22,7 +22,7 @@ import org.infinispan.tutorial.simple.hibernate.cache.local.model.Person;
  * is present in the default lookup location: META-INF/persistence.xml
  *
  * Run with these properties to hide Hibernate messages:
- * -Djava.util.logging.config.file=src/main/resources/logging-app.properties
+ * -Dlog4j.configurationFile=src/main/resources/log4j2-tutorial.xml
  */
 public class InfinispanHibernateCacheLocal {
 
@@ -57,10 +57,14 @@ public class InfinispanHibernateCacheLocal {
       System.out.printf("Event entity cache miss: %d (expected 1)%n", cacheStats.getMissCount());
       System.out.printf("Event entity cache puts: %d (expected 5)%n", cacheStats.getPutCount());
 
-      // Remove cached entity, stats shoudl show a cache hit
+      // Remove cached entity, stats should show a cache hit
       cacheStats = deleteEntity(emf);
       System.out.printf("Event entity cache hits: %d (expected 4)%n", cacheStats.getHitCount());
 
+      // Add a fictional delay so that there's a small enough gap for the
+      // query result set timestamp to be later in time than the update timestamp.
+      // Deleting an entity triggers an invalidation event which updates the timestamp.
+      Thread.sleep(100);
 
       // Query entities, expect:
       // * no cache hits since query is not cached
@@ -154,6 +158,8 @@ public class InfinispanHibernateCacheLocal {
          Event event = em.find(Event.class, id);
          String newName = "Caught a Snorlax!!";
          event.setName("Caught a Snorlax!!");
+
+         System.out.printf("Updated entity: %s%n", event);
 
          return getCacheStatistics(Event.class.getName(), em);
       } catch (Throwable t) {

--- a/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
+++ b/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
@@ -9,6 +9,7 @@ import javax.persistence.Persistence;
 import javax.persistence.TypedQuery;
 
 import org.hibernate.Session;
+import org.hibernate.SessionFactory;
 import org.hibernate.stat.SecondLevelCacheStatistics;
 import org.hibernate.stat.Statistics;
 import org.infinispan.tutorial.simple.hibernate.cache.local.model.Event;
@@ -253,16 +254,12 @@ public class InfinispanHibernateCacheLocal {
 
    private static SecondLevelCacheStatistics getCacheStatistics(
          String regionName, EntityManagerFactory emf) {
-      return ((Session) emf.createEntityManager().getDelegate())
-            .getSessionFactory()
-            .getStatistics()
+      return emf.unwrap(SessionFactory.class).getStatistics()
             .getSecondLevelCacheStatistics(regionName);
    }
 
    private static Statistics getStatistics(EntityManagerFactory emf) {
-      return ((Session) emf.createEntityManager().getDelegate())
-            .getSessionFactory()
-            .getStatistics();
+      return emf.unwrap(SessionFactory.class).getStatistics();
    }
 
 }

--- a/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
+++ b/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
@@ -169,7 +169,6 @@ public class InfinispanHibernateCacheLocal {
          tx.begin();
 
          Event event = em.find(Event.class, id);
-         String newName = "Caught a Snorlax!!";
          event.setName("Caught a Snorlax!!");
 
          System.out.printf("Updated entity: %s%n", event);

--- a/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
+++ b/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
@@ -8,6 +8,7 @@ import javax.persistence.EntityTransaction;
 import javax.persistence.Persistence;
 import javax.persistence.TypedQuery;
 
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.stat.SecondLevelCacheStatistics;
 import org.hibernate.stat.Statistics;
@@ -137,127 +138,111 @@ public class InfinispanHibernateCacheLocal {
    }
 
    private static void persistEntities() {
-      EntityManager em = createEntityManagerWithStatsCleared();
-      EntityTransaction tx = em.getTransaction();
-      try {
-         tx.begin();
+      try(Session em = createEntityManagerWithStatsCleared()) {
+         EntityTransaction tx = em.getTransaction();
+         try {
+            tx.begin();
 
-         em.persist(new Event("Caught a pokemon!"));
-         em.persist(new Event("Hatched an egg"));
-         em.persist(new Event("Became a gym leader"));
-      } catch (Throwable t) {
-         tx.setRollbackOnly();
-         throw t;
-      } finally {
-         if (tx.isActive()) tx.commit();
-         else tx.rollback();
-
-         em.close();
+            em.persist(new Event("Caught a pokemon!"));
+            em.persist(new Event("Hatched an egg"));
+            em.persist(new Event("Became a gym leader"));
+         } catch (Throwable t) {
+            tx.setRollbackOnly();
+            throw t;
+         } finally {
+            if (tx.isActive()) tx.commit();
+            else tx.rollback();
+         }
       }
    }
 
-   private static EntityManager createEntityManagerWithStatsCleared() {
+   private static Session createEntityManagerWithStatsCleared() {
       EntityManager em = emf.createEntityManager();
       emf.unwrap(SessionFactory.class).getStatistics().clear();
-      return em;
+      return em.unwrap(Session.class);
    }
 
    private static void findEntity(long id) {
-      EntityManager em = createEntityManagerWithStatsCleared();
-      try {
+      try(Session em = createEntityManagerWithStatsCleared()) {
          Event event = em.find(Event.class, id);
          System.out.printf("Found entity: %s%n", event);
-      } finally {
-         em.close();
       }
    }
 
    private static void updateEntity(long id) {
-      EntityManager em = createEntityManagerWithStatsCleared();
-      EntityTransaction tx = em.getTransaction();
-      try {
-         tx.begin();
+      try(Session em = createEntityManagerWithStatsCleared()) {
+         EntityTransaction tx = em.getTransaction();
+         try {
+            tx.begin();
 
-         Event event = em.find(Event.class, id);
-         event.setName("Caught a Snorlax!!");
+            Event event = em.find(Event.class, id);
+            event.setName("Caught a Snorlax!!");
 
-         System.out.printf("Updated entity: %s%n", event);
-      } catch (Throwable t) {
-         tx.setRollbackOnly();
-         throw t;
-      } finally {
-         if (tx.isActive()) tx.commit();
-         else tx.rollback();
-
-         em.close();
+            System.out.printf("Updated entity: %s%n", event);
+         } catch (Throwable t) {
+            tx.setRollbackOnly();
+            throw t;
+         } finally {
+            if (tx.isActive()) tx.commit();
+            else tx.rollback();
+         }
       }
    }
 
    private static void evictEntity(long id) {
-      EntityManager em = createEntityManagerWithStatsCleared();
-      try {
+      try(Session em = createEntityManagerWithStatsCleared()) {
          em.getEntityManagerFactory().getCache().evict(Event.class, id);
-      } finally {
-         em.close();
       }
    }
 
    private static void deleteEntity(long id) {
-      EntityManager em = createEntityManagerWithStatsCleared();
-      EntityTransaction tx = em.getTransaction();
-      try {
-         tx.begin();
+      try(Session em = createEntityManagerWithStatsCleared()) {
+         EntityTransaction tx = em.getTransaction();
+         try {
+            tx.begin();
 
-         Event event = em.find(Event.class, id);
-         em.remove(event);
-      } catch (Throwable t) {
-         tx.setRollbackOnly();
-         throw t;
-      } finally {
-         if (tx.isActive()) tx.commit();
-         else tx.rollback();
-
-         em.close();
+            Event event = em.find(Event.class, id);
+            em.remove(event);
+         } catch (Throwable t) {
+            tx.setRollbackOnly();
+            throw t;
+         } finally {
+            if (tx.isActive()) tx.commit();
+            else tx.rollback();
+         }
       }
    }
 
    private static void queryEntities() {
-      EntityManager em = createEntityManagerWithStatsCleared();
-      try {
+      try(Session em = createEntityManagerWithStatsCleared()) {
          TypedQuery<Event> query = em.createQuery("from Event", Event.class);
          query.setHint("org.hibernate.cacheable", Boolean.TRUE);
          List<Event> events = query.getResultList();
          System.out.printf("Queried events: %s%n", events);
-      } finally {
-         em.close();
       }
    }
 
    private static void saveExpiringEntity() {
-      EntityManager em = createEntityManagerWithStatsCleared();
-      EntityTransaction tx = em.getTransaction();
-      try {
-         tx.begin();
+      try(Session em = createEntityManagerWithStatsCleared()) {
+         EntityTransaction tx = em.getTransaction();
+         try {
+            tx.begin();
 
-         em.persist(new Person("Satoshi"));
-      } catch (Throwable t) {
-         tx.setRollbackOnly();
-         throw t;
-      } finally {
-         if (tx.isActive()) tx.commit();
-         else tx.rollback();
-
-         em.close();
+            em.persist(new Person("Satoshi"));
+         } catch (Throwable t) {
+            tx.setRollbackOnly();
+            throw t;
+         } finally {
+            if (tx.isActive()) tx.commit();
+            else tx.rollback();
+         }
       }
    }
 
    private static void findExpiringEntity(long id) {
-      EntityManager em = createEntityManagerWithStatsCleared();
-      try {
+      try(Session em = createEntityManagerWithStatsCleared()) {
          Person person = em.find(Person.class, id);
          System.out.printf("Found expiring entity: %s%n", person);
-      } finally {
-         em.close();
       }
    }
 

--- a/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
+++ b/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
@@ -24,6 +24,8 @@ import org.infinispan.tutorial.simple.hibernate.cache.local.model.Person;
  *
  * Run with these properties to hide Hibernate messages:
  * -Dlog4j.configurationFile=src/main/resources/log4j2-tutorial.xml
+ *
+ * Run with -ea to enable assertions and verify expected behaviour.
  */
 public class InfinispanHibernateCacheLocal {
 
@@ -38,23 +40,23 @@ public class InfinispanHibernateCacheLocal {
       // Persist 3 entities, stats should show 3 second level cache puts
       persistEntities(emf);
       eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
-      System.out.printf("Event entity cache puts: %d (expected 3)%n", eventCacheStats.getPutCount());
+      printfAssert("Event entity cache puts: %d (expected %d)%n", eventCacheStats.getPutCount(), 3);
 
       // Find one of the persisted entities, stats should show a cache hit
       findEntity(1L, emf);
       eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
-      System.out.printf("Event entity cache hits: %d (expected 1)%n", eventCacheStats.getHitCount());
+      printfAssert("Event entity cache hits: %d (expected %d)%n", eventCacheStats.getHitCount(), 1);
 
       // Update one of the persisted entities, stats should show a cache hit and a cache put
       updateEntity(1L, emf);
       eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
-      System.out.printf("Event entity cache hits: %d (expected 2)%n", eventCacheStats.getHitCount());
-      System.out.printf("Event entity cache puts: %d (expected 4)%n", eventCacheStats.getPutCount());
+      printfAssert("Event entity cache hits: %d (expected %d)%n", eventCacheStats.getHitCount(), 2);
+      printfAssert("Event entity cache puts: %d (expected %d)%n", eventCacheStats.getPutCount(), 4);
 
       // Find the updated entity, stats should show a cache hit
       findEntity(1L, emf);
       eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
-      System.out.printf("Event entity cache hits: %d (expected 3)%n", eventCacheStats.getHitCount());
+      printfAssert("Event entity cache hits: %d (expected %d)%n", eventCacheStats.getHitCount(), 3);
 
 
       // Evict entity from cache
@@ -64,13 +66,13 @@ public class InfinispanHibernateCacheLocal {
       // Stats should show a cache miss and a cache put
       findEntity(1L, emf);
       eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
-      System.out.printf("Event entity cache miss: %d (expected 1)%n", eventCacheStats.getMissCount());
-      System.out.printf("Event entity cache puts: %d (expected 5)%n", eventCacheStats.getPutCount());
+      printfAssert("Event entity cache miss: %d (expected %d)%n", eventCacheStats.getMissCount(), 1);
+      printfAssert("Event entity cache puts: %d (expected %d)%n", eventCacheStats.getPutCount(), 5);
 
       // Remove cached entity, stats should show a cache hit
       deleteEntity(1L, emf);
       eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
-      System.out.printf("Event entity cache hits: %d (expected 4)%n", eventCacheStats.getHitCount());
+      printfAssert("Event entity cache hits: %d (expected %d)%n", eventCacheStats.getHitCount(), 4);
 
       // Add a fictional delay so that there's a small enough gap for the
       // query result set timestamp to be later in time than the update timestamp.
@@ -82,22 +84,22 @@ public class InfinispanHibernateCacheLocal {
       // * a query cache miss and query cache put
       queryEntities(emf);
       stats = getStatistics(emf);
-      System.out.printf("Query cache miss: %d (expected 1)%n", stats.getQueryCacheMissCount());
-      System.out.printf("Query cache put: %d (expected 1)%n", stats.getQueryCachePutCount());
+      printfAssert("Query cache miss: %d (expected %d)%n", stats.getQueryCacheMissCount(), 1);
+      printfAssert("Query cache put: %d (expected %d)%n", stats.getQueryCachePutCount(), 1);
 
       // Repeat query, expect:
       // * two cache hits for the number of entities in cache
       // * a query cache hit
       queryEntities(emf);
       stats = getStatistics(emf);
-      System.out.printf("Event entity cache hits: %d (expected 6)%n", stats.getSecondLevelCacheHitCount());
-      System.out.printf("Query cache hit: %d (expected 1)%n", stats.getQueryCacheHitCount());
+      printfAssert("Event entity cache hits: %d (expected %d)%n", stats.getSecondLevelCacheHitCount(), 6);
+      printfAssert("Query cache hit: %d (expected %d)%n", stats.getQueryCacheHitCount(), 1);
 
       // Update one of the persisted entities, stats should show a cache hit and a cache put
       updateEntity(2L, emf);
       eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
-      System.out.printf("Event entity cache hits: %d (expected 7)%n", eventCacheStats.getHitCount());
-      System.out.printf("Event entity cache puts: %d (expected 6)%n", eventCacheStats.getPutCount());
+      printfAssert("Event entity cache hits: %d (expected %d)%n", eventCacheStats.getHitCount(), 7);
+      printfAssert("Event entity cache puts: %d (expected %d)%n", eventCacheStats.getPutCount(), 6);
 
       // Repeat query after update, expect:
       // * no cache hits or puts since entities are already cached
@@ -105,19 +107,19 @@ public class InfinispanHibernateCacheLocal {
       //   any queries for that type are invalidated
       queryEntities(emf);
       stats = getStatistics(emf);
-      System.out.printf("Query cache miss: %d (expected 2)%n", stats.getQueryCacheMissCount());
-      System.out.printf("Query cache put: %d (expected 2)%n", stats.getQueryCachePutCount());
+      printfAssert("Query cache miss: %d (expected %d)%n", stats.getQueryCacheMissCount(),2);
+      printfAssert("Query cache put: %d (expected %d)%n", stats.getQueryCachePutCount(), 2);
 
 
       // Save cache-expiring entity, stats should show a second level cache put
       saveExpiringEntity(emf);
       personCacheStats = getCacheStatistics(Person.class.getName(), emf);
-      System.out.printf("Person entity cache puts: %d (expected 1)%n", personCacheStats.getPutCount());
+      printfAssert("Person entity cache puts: %d (expected %d)%n", personCacheStats.getPutCount(), 1);
 
       // Find expiring entity, stats should show a second level cache hit
       findExpiringEntity(4L, emf);
       personCacheStats = getCacheStatistics(Person.class.getName(), emf);
-      System.out.printf("Person entity cache hits: %d (expected 1)%n", personCacheStats.getHitCount());
+      printfAssert("Person entity cache hits: %d (expected %d)%n", personCacheStats.getHitCount(), 1);
 
       // Wait long enough for entity to be expired from cache
       Thread.sleep(1100);
@@ -126,8 +128,8 @@ public class InfinispanHibernateCacheLocal {
       // Stats should show a cache miss and a cache put
       findExpiringEntity(4L, emf);
       personCacheStats = getCacheStatistics(Person.class.getName(), emf);
-      System.out.printf("Person entity cache miss: %d (expected 1)%n", personCacheStats.getMissCount());
-      System.out.printf("Person entity cache put: %d (expected 2)%n", personCacheStats.getPutCount());
+      printfAssert("Person entity cache miss: %d (expected %d)%n", personCacheStats.getMissCount(), 1);
+      printfAssert("Person entity cache put: %d (expected %d)%n", personCacheStats.getPutCount(), 2);
 
       // Close persistence manager
       emf.close();
@@ -260,6 +262,11 @@ public class InfinispanHibernateCacheLocal {
 
    private static Statistics getStatistics(EntityManagerFactory emf) {
       return emf.unwrap(SessionFactory.class).getStatistics();
+   }
+
+   private static void printfAssert(String format, long actual, int expected) {
+      System.out.printf(format, actual, expected);
+      assert expected == actual : "Expected: " + expected + ", actual: " + actual;
    }
 
 }

--- a/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
+++ b/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
@@ -57,7 +57,7 @@ public class InfinispanHibernateCacheLocal {
 
 
       // Evict entity from cache
-      evictEntity(emf);
+      evictEntity(1L, emf);
 
       // Reload evicted entity, should come from DB
       // Stats should show a cache miss and a cache put
@@ -67,7 +67,7 @@ public class InfinispanHibernateCacheLocal {
       System.out.printf("Event entity cache puts: %d (expected 5)%n", eventCacheStats.getPutCount());
 
       // Remove cached entity, stats should show a cache hit
-      deleteEntity(emf);
+      deleteEntity(1L, emf);
       eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
       System.out.printf("Event entity cache hits: %d (expected 4)%n", eventCacheStats.getHitCount());
 
@@ -114,7 +114,7 @@ public class InfinispanHibernateCacheLocal {
       System.out.printf("Person entity cache puts: %d (expected 1)%n", personCacheStats.getPutCount());
 
       // Find expiring entity, stats should show a second level cache hit
-      findExpiringEntity(emf);
+      findExpiringEntity(4L, emf);
       personCacheStats = getCacheStatistics(Person.class.getName(), emf);
       System.out.printf("Person entity cache hits: %d (expected 1)%n", personCacheStats.getHitCount());
 
@@ -123,7 +123,7 @@ public class InfinispanHibernateCacheLocal {
 
       // Find expiring entity, after expiration entity should come from DB
       // Stats should show a cache miss and a cache put
-      findExpiringEntity(emf);
+      findExpiringEntity(4L, emf);
       personCacheStats = getCacheStatistics(Person.class.getName(), emf);
       System.out.printf("Person entity cache miss: %d (expected 1)%n", personCacheStats.getMissCount());
       System.out.printf("Person entity cache put: %d (expected 2)%n", personCacheStats.getPutCount());
@@ -183,22 +183,22 @@ public class InfinispanHibernateCacheLocal {
       }
    }
 
-   private static void evictEntity(EntityManagerFactory emf) {
+   private static void evictEntity(long id, EntityManagerFactory emf) {
       EntityManager em = emf.createEntityManager();
       try {
-         em.getEntityManagerFactory().getCache().evict(Event.class, 1L);
+         em.getEntityManagerFactory().getCache().evict(Event.class, id);
       } finally {
          em.close();
       }
    }
 
-   private static void deleteEntity(EntityManagerFactory emf) {
+   private static void deleteEntity(long id, EntityManagerFactory emf) {
       EntityManager em = emf.createEntityManager();
       EntityTransaction tx = em.getTransaction();
       try {
          tx.begin();
 
-         Event event = em.find(Event.class, 1L);
+         Event event = em.find(Event.class, id);
          em.remove(event);
       } catch (Throwable t) {
          tx.setRollbackOnly();
@@ -241,10 +241,10 @@ public class InfinispanHibernateCacheLocal {
       }
    }
 
-   private static void findExpiringEntity(EntityManagerFactory emf) {
+   private static void findExpiringEntity(long id, EntityManagerFactory emf) {
       EntityManager em = emf.createEntityManager();
       try {
-         Person person = em.find(Person.class, 4L);
+         Person person = em.find(Person.class, id);
          System.out.printf("Found expiring entity: %s%n", person);
       } finally {
          em.close();

--- a/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
+++ b/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
@@ -40,7 +40,7 @@ public class InfinispanHibernateCacheLocal {
       System.out.printf("Event entity cache puts: %d (expected 3)%n", eventCacheStats.getPutCount());
 
       // Find one of the persisted entities, stats should show a cache hit
-      findEntity(emf);
+      findEntity(1L, emf);
       eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
       System.out.printf("Event entity cache hits: %d (expected 1)%n", eventCacheStats.getHitCount());
 
@@ -51,7 +51,7 @@ public class InfinispanHibernateCacheLocal {
       System.out.printf("Event entity cache puts: %d (expected 4)%n", eventCacheStats.getPutCount());
 
       // Find the updated entity, stats should show a cache hit
-      findEntity(emf);
+      findEntity(1L, emf);
       eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
       System.out.printf("Event entity cache hits: %d (expected 3)%n", eventCacheStats.getHitCount());
 
@@ -61,7 +61,7 @@ public class InfinispanHibernateCacheLocal {
 
       // Reload evicted entity, should come from DB
       // Stats should show a cache miss and a cache put
-      findEntity(emf);
+      findEntity(1L, emf);
       eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
       System.out.printf("Event entity cache miss: %d (expected 1)%n", eventCacheStats.getMissCount());
       System.out.printf("Event entity cache puts: %d (expected 5)%n", eventCacheStats.getPutCount());
@@ -152,10 +152,10 @@ public class InfinispanHibernateCacheLocal {
       }
    }
 
-   private static void findEntity(EntityManagerFactory emf) {
+   private static void findEntity(long id, EntityManagerFactory emf) {
       EntityManager em = emf.createEntityManager();
       try {
-         Event event = em.find(Event.class, 1L);
+         Event event = em.find(Event.class, id);
          System.out.printf("Found entity: %s%n", event);
       } finally {
          em.close();

--- a/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
+++ b/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/InfinispanHibernateCacheLocal.java
@@ -28,49 +28,51 @@ import org.infinispan.tutorial.simple.hibernate.cache.local.model.Person;
  */
 public class InfinispanHibernateCacheLocal {
 
+   private static EntityManagerFactory emf;
+
    public static void main(String[] args) throws Exception {
       // Create JPA persistence manager
-      EntityManagerFactory emf = Persistence.createEntityManagerFactory("events");
+      emf = Persistence.createEntityManagerFactory("events");
 
       SecondLevelCacheStatistics eventCacheStats;
       SecondLevelCacheStatistics personCacheStats;
       Statistics stats;
 
       // Persist 3 entities, stats should show 3 second level cache puts
-      persistEntities(emf);
-      eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
+      persistEntities();
+      eventCacheStats = getCacheStatistics(Event.class.getName());
       printfAssert("Event entity cache puts: %d (expected %d)%n", eventCacheStats.getPutCount(), 3);
 
       // Find one of the persisted entities, stats should show a cache hit
-      findEntity(1L, emf);
-      eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
+      findEntity(1L);
+      eventCacheStats = getCacheStatistics(Event.class.getName());
       printfAssert("Event entity cache hits: %d (expected %d)%n", eventCacheStats.getHitCount(), 1);
 
       // Update one of the persisted entities, stats should show a cache hit and a cache put
-      updateEntity(1L, emf);
-      eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
+      updateEntity(1L);
+      eventCacheStats = getCacheStatistics(Event.class.getName());
       printfAssert("Event entity cache hits: %d (expected %d)%n", eventCacheStats.getHitCount(), 1);
       printfAssert("Event entity cache puts: %d (expected %d)%n", eventCacheStats.getPutCount(), 1);
 
       // Find the updated entity, stats should show a cache hit
-      findEntity(1L, emf);
-      eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
+      findEntity(1L);
+      eventCacheStats = getCacheStatistics(Event.class.getName());
       printfAssert("Event entity cache hits: %d (expected %d)%n", eventCacheStats.getHitCount(), 1);
 
 
       // Evict entity from cache
-      evictEntity(1L, emf);
+      evictEntity(1L);
 
       // Reload evicted entity, should come from DB
       // Stats should show a cache miss and a cache put
-      findEntity(1L, emf);
-      eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
+      findEntity(1L);
+      eventCacheStats = getCacheStatistics(Event.class.getName());
       printfAssert("Event entity cache miss: %d (expected %d)%n", eventCacheStats.getMissCount(), 1);
       printfAssert("Event entity cache puts: %d (expected %d)%n", eventCacheStats.getPutCount(), 1);
 
       // Remove cached entity, stats should show a cache hit
-      deleteEntity(1L, emf);
-      eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
+      deleteEntity(1L);
+      eventCacheStats = getCacheStatistics(Event.class.getName());
       printfAssert("Event entity cache hits: %d (expected %d)%n", eventCacheStats.getHitCount(), 1);
 
       // Add a fictional delay so that there's a small enough gap for the
@@ -81,22 +83,22 @@ public class InfinispanHibernateCacheLocal {
       // Query entities, expect:
       // * no cache hits since query is not cached
       // * a query cache miss and query cache put
-      queryEntities(emf);
-      stats = getStatistics(emf);
+      queryEntities();
+      stats = getStatistics();
       printfAssert("Query cache miss: %d (expected %d)%n", stats.getQueryCacheMissCount(), 1);
       printfAssert("Query cache put: %d (expected %d)%n", stats.getQueryCachePutCount(), 1);
 
       // Repeat query, expect:
       // * two cache hits for the number of entities in cache
       // * a query cache hit
-      queryEntities(emf);
-      stats = getStatistics(emf);
+      queryEntities();
+      stats = getStatistics();
       printfAssert("Event entity cache hits: %d (expected %d)%n", stats.getSecondLevelCacheHitCount(), 2);
       printfAssert("Query cache hit: %d (expected %d)%n", stats.getQueryCacheHitCount(), 1);
 
       // Update one of the persisted entities, stats should show a cache hit and a cache put
-      updateEntity(2L, emf);
-      eventCacheStats = getCacheStatistics(Event.class.getName(), emf);
+      updateEntity(2L);
+      eventCacheStats = getCacheStatistics(Event.class.getName());
       printfAssert("Event entity cache hits: %d (expected %d)%n", eventCacheStats.getHitCount(), 1);
       printfAssert("Event entity cache puts: %d (expected %d)%n", eventCacheStats.getPutCount(), 1);
 
@@ -104,20 +106,20 @@ public class InfinispanHibernateCacheLocal {
       // * no cache hits or puts since entities are already cached
       // * a query cache miss and query cache put, because when an entity is updated,
       //   any queries for that type are invalidated
-      queryEntities(emf);
-      stats = getStatistics(emf);
+      queryEntities();
+      stats = getStatistics();
       printfAssert("Query cache miss: %d (expected %d)%n", stats.getQueryCacheMissCount(),1);
       printfAssert("Query cache put: %d (expected %d)%n", stats.getQueryCachePutCount(), 1);
 
 
       // Save cache-expiring entity, stats should show a second level cache put
-      saveExpiringEntity(emf);
-      personCacheStats = getCacheStatistics(Person.class.getName(), emf);
+      saveExpiringEntity();
+      personCacheStats = getCacheStatistics(Person.class.getName());
       printfAssert("Person entity cache puts: %d (expected %d)%n", personCacheStats.getPutCount(), 1);
 
       // Find expiring entity, stats should show a second level cache hit
-      findExpiringEntity(4L, emf);
-      personCacheStats = getCacheStatistics(Person.class.getName(), emf);
+      findExpiringEntity(4L);
+      personCacheStats = getCacheStatistics(Person.class.getName());
       printfAssert("Person entity cache hits: %d (expected %d)%n", personCacheStats.getHitCount(), 1);
 
       // Wait long enough for entity to be expired from cache
@@ -125,8 +127,8 @@ public class InfinispanHibernateCacheLocal {
 
       // Find expiring entity, after expiration entity should come from DB
       // Stats should show a cache miss and a cache put
-      findExpiringEntity(4L, emf);
-      personCacheStats = getCacheStatistics(Person.class.getName(), emf);
+      findExpiringEntity(4L);
+      personCacheStats = getCacheStatistics(Person.class.getName());
       printfAssert("Person entity cache miss: %d (expected %d)%n", personCacheStats.getMissCount(), 1);
       printfAssert("Person entity cache put: %d (expected %d)%n", personCacheStats.getPutCount(), 1);
 
@@ -134,8 +136,8 @@ public class InfinispanHibernateCacheLocal {
       emf.close();
    }
 
-   private static void persistEntities(EntityManagerFactory emf) {
-      EntityManager em = createEntityManagerWithStatsCleared(emf);
+   private static void persistEntities() {
+      EntityManager em = createEntityManagerWithStatsCleared();
       EntityTransaction tx = em.getTransaction();
       try {
          tx.begin();
@@ -154,14 +156,14 @@ public class InfinispanHibernateCacheLocal {
       }
    }
 
-   private static EntityManager createEntityManagerWithStatsCleared(EntityManagerFactory emf) {
+   private static EntityManager createEntityManagerWithStatsCleared() {
       EntityManager em = emf.createEntityManager();
       emf.unwrap(SessionFactory.class).getStatistics().clear();
       return em;
    }
 
-   private static void findEntity(long id, EntityManagerFactory emf) {
-      EntityManager em = createEntityManagerWithStatsCleared(emf);
+   private static void findEntity(long id) {
+      EntityManager em = createEntityManagerWithStatsCleared();
       try {
          Event event = em.find(Event.class, id);
          System.out.printf("Found entity: %s%n", event);
@@ -170,8 +172,8 @@ public class InfinispanHibernateCacheLocal {
       }
    }
 
-   private static void updateEntity(long id, EntityManagerFactory emf) {
-      EntityManager em = createEntityManagerWithStatsCleared(emf);
+   private static void updateEntity(long id) {
+      EntityManager em = createEntityManagerWithStatsCleared();
       EntityTransaction tx = em.getTransaction();
       try {
          tx.begin();
@@ -191,8 +193,8 @@ public class InfinispanHibernateCacheLocal {
       }
    }
 
-   private static void evictEntity(long id, EntityManagerFactory emf) {
-      EntityManager em = createEntityManagerWithStatsCleared(emf);
+   private static void evictEntity(long id) {
+      EntityManager em = createEntityManagerWithStatsCleared();
       try {
          em.getEntityManagerFactory().getCache().evict(Event.class, id);
       } finally {
@@ -200,8 +202,8 @@ public class InfinispanHibernateCacheLocal {
       }
    }
 
-   private static void deleteEntity(long id, EntityManagerFactory emf) {
-      EntityManager em = createEntityManagerWithStatsCleared(emf);
+   private static void deleteEntity(long id) {
+      EntityManager em = createEntityManagerWithStatsCleared();
       EntityTransaction tx = em.getTransaction();
       try {
          tx.begin();
@@ -219,8 +221,8 @@ public class InfinispanHibernateCacheLocal {
       }
    }
 
-   private static void queryEntities(EntityManagerFactory emf) {
-      EntityManager em = createEntityManagerWithStatsCleared(emf);
+   private static void queryEntities() {
+      EntityManager em = createEntityManagerWithStatsCleared();
       try {
          TypedQuery<Event> query = em.createQuery("from Event", Event.class);
          query.setHint("org.hibernate.cacheable", Boolean.TRUE);
@@ -231,8 +233,8 @@ public class InfinispanHibernateCacheLocal {
       }
    }
 
-   private static void saveExpiringEntity(EntityManagerFactory emf) {
-      EntityManager em = createEntityManagerWithStatsCleared(emf);
+   private static void saveExpiringEntity() {
+      EntityManager em = createEntityManagerWithStatsCleared();
       EntityTransaction tx = em.getTransaction();
       try {
          tx.begin();
@@ -249,8 +251,8 @@ public class InfinispanHibernateCacheLocal {
       }
    }
 
-   private static void findExpiringEntity(long id, EntityManagerFactory emf) {
-      EntityManager em = createEntityManagerWithStatsCleared(emf);
+   private static void findExpiringEntity(long id) {
+      EntityManager em = createEntityManagerWithStatsCleared();
       try {
          Person person = em.find(Person.class, id);
          System.out.printf("Found expiring entity: %s%n", person);
@@ -259,19 +261,23 @@ public class InfinispanHibernateCacheLocal {
       }
    }
 
-   private static SecondLevelCacheStatistics getCacheStatistics(
-         String regionName, EntityManagerFactory emf) {
+   private static SecondLevelCacheStatistics getCacheStatistics(String regionName) {
       return emf.unwrap(SessionFactory.class).getStatistics()
             .getSecondLevelCacheStatistics(regionName);
    }
 
-   private static Statistics getStatistics(EntityManagerFactory emf) {
+   private static Statistics getStatistics() {
       return emf.unwrap(SessionFactory.class).getStatistics();
    }
 
    private static void printfAssert(String format, long actual, int expected) {
       System.out.printf(format, actual, expected);
-      assert expected == actual : "Expected: " + expected + ", actual: " + actual;
+      assert expected == actual : errorMsgAndCloseEntityManagerFactory(actual, expected);
+   }
+
+   private static String errorMsgAndCloseEntityManagerFactory(long actual, int expected) {
+      emf.close();
+      return "Expected: " + expected + ", actual: " + actual;
    }
 
 }

--- a/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/model/Event.java
+++ b/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/model/Event.java
@@ -1,0 +1,68 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.infinispan.tutorial.simple.hibernate.cache.local.model;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@Cacheable
+public class Event {
+
+   @Id
+   @GeneratedValue
+   private Long id;
+
+   private String name;
+
+   private LocalDateTime timestamp = LocalDateTime.now();
+
+   public Event(String name) {
+      this.name = name;
+   }
+
+   public Event() {
+   }
+
+   public Long getId() {
+      return id;
+   }
+
+   public void setId(Long id) {
+      this.id = id;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   public LocalDateTime getTimestamp() {
+      return timestamp;
+   }
+
+   public void setTimestamp(LocalDateTime timestamp) {
+      this.timestamp = timestamp;
+   }
+
+   @Override
+   public String toString() {
+      return "Event{" +
+            "id=" + id +
+            ", name='" + name + '\'' +
+            ", time=" + timestamp +
+            '}';
+   }
+
+}

--- a/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/model/Person.java
+++ b/hibernate-cache-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/local/model/Person.java
@@ -1,0 +1,48 @@
+package org.infinispan.tutorial.simple.hibernate.cache.local.model;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@Cacheable
+public class Person {
+
+   @Id
+   @GeneratedValue
+   private Long id;
+   private String name;
+
+   public Person(String name) {
+      this.name = name;
+   }
+
+   public Person() {
+   }
+
+   public Long getId() {
+      return id;
+   }
+
+   public void setId(Long id) {
+      this.id = id;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String firstName) {
+      this.name = firstName;
+   }
+
+   @Override
+   public String toString() {
+      return "Person{" +
+            "id=" + id +
+            ", name='" + name + '\'' +
+            '}';
+   }
+
+}

--- a/hibernate-cache-local/src/main/resources/META-INF/persistence.xml
+++ b/hibernate-cache-local/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.1"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="
+        http://xmlns.jcp.org/xml/ns/persistence
+        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+   <persistence-unit name="events">
+      <shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>
+      <properties>
+         <!-- H2 in-memory database -->
+         <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+         <property name="hibernate.connection.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE"/>
+         <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
+         <property name="hibernate.connection.username" value="sa"/>
+         <property name="hibernate.connection.password" value=""/>
+
+         <!-- Create/drop database in each run -->
+         <property name="hibernate.hbm2ddl.auto" value="create-drop" />
+
+         <!-- Enables second level cache -->
+         <property name="hibernate.cache.use_second_level_cache" value="true"/>
+         <!-- Enable query cache -->
+         <property name="hibernate.cache.use_query_cache" value="true"/>
+
+         <!-- Use Infinispan second level cache provider -->
+         <property name="hibernate.cache.region.factory_class"
+                   value="infinispan"/>
+         <!-- Force using local configuration when only using a single node.
+              Otherwise a clustered configuration is loaded. -->
+         <property name="hibernate.cache.infinispan.cfg"
+                   value="org/infinispan/hibernate/cache/builder/infinispan-configs-local.xml"/>
+
+         <!-- Generate statistics to see effects of second level cache -->
+         <property name="hibernate.generate_statistics" value="true" />
+
+         <!-- Entity specific configuration, e.g. via property:
+                 hibernate.cache.infinispan.<Entity FQN>.expiration.max_idle
+         -->
+         <property name="hibernate.cache.infinispan.org.infinispan.tutorial.simple.hibernate.cache.local.model.Person.expiration.max_idle"
+                   value= "1000"/>
+      </properties>
+   </persistence-unit>
+</persistence>

--- a/hibernate-cache-local/src/main/resources/log4j2-tutorial.xml
+++ b/hibernate-cache-local/src/main/resources/log4j2-tutorial.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration verbose="false" status="warn" packages="org.infinispan.util.logging.log4j">
+
+   <Appenders>
+      <File name="FileAppender" fileName="tutorial.log" append="false">
+         <ThresholdFilter level="error"/>
+         <!--<ThresholdFilter level="trace"/>-->
+         <PatternLayout pattern="%d %-5p [%c] (%t:%x) %m%n"/>
+      </File>
+   </Appenders>
+
+   <Loggers>
+       <Logger name="org.hibernate" level="trace" />
+       <Logger name="org.infinispan" level="trace" />
+       <Logger name="org.infinispan.factories" level="debug" />
+       <Logger name="org.infinispan.jmx" level="debug" />
+       <Logger name="org.infinispan.marshall.core" level="trace" />
+       <Logger name="com.mchange" level="warn"/>
+       <Logger name="org.jgroups" level="info"/>
+       <Logger name="org.jgroups.protocols.relay" level="trace"/>
+       <Root level="info">
+          <AppenderRef ref="FileAppender"/>
+       </Root>
+   </Loggers>
+
+</Configuration>

--- a/hibernate-cache-local/src/main/resources/logging-app.properties
+++ b/hibernate-cache-local/src/main/resources/logging-app.properties
@@ -1,6 +1,0 @@
-handlers=java.util.logging.ConsoleHandler
-.level=INFO
-
-# Change level to INFO to see Hibernate log messages
-java.util.logging.ConsoleHandler.level=SEVERE
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter

--- a/hibernate-cache-local/src/main/resources/logging-app.properties
+++ b/hibernate-cache-local/src/main/resources/logging-app.properties
@@ -1,0 +1,6 @@
+handlers=java.util.logging.ConsoleHandler
+.level=INFO
+
+# Change level to INFO to see Hibernate log messages
+java.util.logging.ConsoleHandler.level=SEVERE
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
        <module>listen</module>
        <module>remote-listen</module>
        <module>kubernetes</module>
+       <module>hibernate-cache-local</module>
     </modules>
 </project>
 


### PR DESCRIPTION
Preview PR for the first of the Hibernate cache provider tutorials.

This first tutorial is focused on using Hibernate cache provider in a standalone, single-node, environment.

The tutorial randomly shows different counts, which I need to debug further. Also, the PR uses a snapshot, so do not yet integrate it. 

Let's just use this PR to get some feedback on the tutorial itself.