### PR TITLE
ISPN-8029 Update to 9.0.3.Final and avoid uber jar dependencies

### DIFF
--- a/clusterexec/pom.xml
+++ b/clusterexec/pom.xml
@@ -38,7 +38,7 @@
     <dependencies>
       <dependency>
         <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-embedded</artifactId>
+        <artifactId>infinispan-core</artifactId>
       </dependency>
     </dependencies>
 </project>

--- a/distexec/pom.xml
+++ b/distexec/pom.xml
@@ -38,7 +38,7 @@
     <dependencies>
       <dependency>
         <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-embedded</artifactId>
+        <artifactId>infinispan-core</artifactId>
       </dependency>
     </dependencies>
 </project>

--- a/distributed/pom.xml
+++ b/distributed/pom.xml
@@ -40,7 +40,7 @@
     <dependencies>
       <dependency>
         <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-embedded</artifactId>
+        <artifactId>infinispan-core</artifactId>
       </dependency>
     </dependencies>
 </project>

--- a/functional/pom.xml
+++ b/functional/pom.xml
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-embedded</artifactId>
+            <artifactId>infinispan-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/jcache/pom.xml
+++ b/jcache/pom.xml
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-embedded</artifactId>
+            <artifactId>infinispan-jcache</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.cache</groupId>

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -69,7 +69,7 @@
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-embedded</artifactId>
+            <artifactId>infinispan-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/listen/pom.xml
+++ b/listen/pom.xml
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-embedded</artifactId>
+            <artifactId>infinispan-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/map/pom.xml
+++ b/map/pom.xml
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-embedded</artifactId>
+            <artifactId>infinispan-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>Infinispan Tutorial: Simple tutorials</name>
 
     <properties>
-       <version.infinispan>9.0.1.Final</version.infinispan>
+       <version.infinispan>9.0.3.Final</version.infinispan>
     </properties>
 
     <dependencyManagement>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -39,11 +39,11 @@
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-embedded</artifactId>
+            <artifactId>infinispan-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-embedded-query</artifactId>
+            <artifactId>infinispan-query</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/remote-listen/pom.xml
+++ b/remote-listen/pom.xml
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-remote</artifactId>
+            <artifactId>infinispan-client-hotrod</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/remote/pom.xml
+++ b/remote/pom.xml
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-remote</artifactId>
+            <artifactId>infinispan-client-hotrod</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/replicated/pom.xml
+++ b/replicated/pom.xml
@@ -40,7 +40,7 @@
     <dependencies>
       <dependency>
         <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-embedded</artifactId>
+        <artifactId>infinispan-core</artifactId>
       </dependency>
     </dependencies>
 </project>

--- a/scripting/pom.xml
+++ b/scripting/pom.xml
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-remote</artifactId>
+            <artifactId>infinispan-client-hotrod</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -58,7 +58,7 @@
     <dependencies>
       <dependency>
         <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-embedded</artifactId>
+        <artifactId>infinispan-core</artifactId>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>

--- a/streams/pom.xml
+++ b/streams/pom.xml
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-embedded</artifactId>
+            <artifactId>infinispan-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/tx/pom.xml
+++ b/tx/pom.xml
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-embedded</artifactId>
+            <artifactId>infinispan-core</artifactId>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Infinispan update needed so that users don't need to add `infinispan-core` dependency when using embedded JCache impl (`infinispan-jcache`).