### PR TITLE
ISPN-8024 Local Spring Infinispan Hibernate cache tutorial

### DIFF
--- a/hibernate-cache/spring-local/pom.xml
+++ b/hibernate-cache/spring-local/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <modelVersion>4.0.0</modelVersion>
+
+   <groupId>org.infinispan.tutorial.simple</groupId>
+   <name>Infinispan Simple Tutorials: Hibernate Cache Spring Local</name>
+   <artifactId>infinispan-simple-tutorials-hibernate-cache-spring-local</artifactId>
+   <version>1.0.0-SNAPSHOT</version>
+
+   <parent>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-parent</artifactId>
+      <!--<version>1.5.9.RELEASE</version>-->
+      <version>2.0.0.M7</version>
+   </parent>
+
+   <properties>
+      <java.version>1.8</java.version>
+
+      <version.infinispan>9.2.0-SNAPSHOT</version.infinispan>
+   </properties>
+
+   <dependencyManagement>
+      <dependencies>
+         <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-bom</artifactId>
+            <version>${version.infinispan}</version>
+            <type>pom</type>
+            <scope>import</scope>
+         </dependency>
+      </dependencies>
+   </dependencyManagement>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-starter-data-jpa</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>com.h2database</groupId>
+         <artifactId>h2</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-hibernate-cache</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-starter-test</artifactId>
+         <scope>test</scope>
+      </dependency>
+   </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-maven-plugin</artifactId>
+         </plugin>
+      </plugins>
+   </build>
+
+   <repositories>
+      <repository>
+         <id>spring-releases</id>
+         <name>Spring Releases</name>
+         <url>https://repo.spring.io/libs-release</url>
+      </repository>
+      <repository>
+         <id>org.jboss.repository.releases</id>
+         <name>JBoss Maven Release Repository</name>
+         <url>https://repository.jboss.org/nexus/content/repositories/releases</url>
+      </repository>
+   </repositories>
+
+   <pluginRepositories>
+      <pluginRepository>
+         <id>spring-releases</id>
+         <name>Spring Releases</name>
+         <url>https://repo.spring.io/libs-release</url>
+      </pluginRepository>
+   </pluginRepositories>
+
+</project>

--- a/hibernate-cache/spring-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/spring/local/InfinispanHibernateCacheSpringLocal.java
+++ b/hibernate-cache/spring-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/spring/local/InfinispanHibernateCacheSpringLocal.java
@@ -1,0 +1,266 @@
+package org.infinispan.tutorial.simple.hibernate.cache.spring.local;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.hibernate.stat.Statistics;
+import org.infinispan.tutorial.simple.hibernate.cache.spring.local.model.Event;
+import org.infinispan.tutorial.simple.hibernate.cache.spring.local.model.Person;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+import javax.persistence.TypedQuery;
+import java.util.List;
+
+@SpringBootApplication
+public class InfinispanHibernateCacheSpringLocal {
+
+   private static final Logger log = LoggerFactory.getLogger(InfinispanHibernateCacheSpringLocal.class);
+
+   @Autowired
+   private EntityManagerFactory emf;
+
+   @Bean
+   public CommandLineRunner demo() {
+      return (args) -> {
+         SecondLevelCacheStatistics eventCacheStats;
+         SecondLevelCacheStatistics personCacheStats;
+         Statistics stats;
+
+         // Persist 3 entities, stats should show 3 second level cache puts
+         persistEntities();
+         eventCacheStats = getCacheStatistics(Event.class.getName());
+         printfAssert("Event entity cache puts: %d (expected %d)", eventCacheStats.getPutCount(), 3);
+
+         // Find one of the persisted entities, stats should show a cache hit
+         findEntity(1L);
+         eventCacheStats = getCacheStatistics(Event.class.getName());
+         printfAssert("Event entity cache hits: %d (expected %d)", eventCacheStats.getHitCount(), 1);
+
+         // Update one of the persisted entities, stats should show a cache hit and a cache put
+         updateEntity(1L);
+         eventCacheStats = getCacheStatistics(Event.class.getName());
+         printfAssert("Event entity cache hits: %d (expected %d)", eventCacheStats.getHitCount(), 1);
+         printfAssert("Event entity cache puts: %d (expected %d)", eventCacheStats.getPutCount(), 1);
+
+         // Find the updated entity, stats should show a cache hit
+         findEntity(1L);
+         eventCacheStats = getCacheStatistics(Event.class.getName());
+         printfAssert("Event entity cache hits: %d (expected %d)", eventCacheStats.getHitCount(), 1);
+
+
+         // Evict entity from cache
+         evictEntity(1L);
+
+         // Reload evicted entity, should come from DB
+         // Stats should show a cache miss and a cache put
+         findEntity(1L);
+         eventCacheStats = getCacheStatistics(Event.class.getName());
+         printfAssert("Event entity cache miss: %d (expected %d)%n", eventCacheStats.getMissCount(), 1);
+         printfAssert("Event entity cache puts: %d (expected %d)%n", eventCacheStats.getPutCount(), 1);
+
+         // Remove cached entity, stats should show a cache hit
+         deleteEntity(1L);
+         eventCacheStats = getCacheStatistics(Event.class.getName());
+         printfAssert("Event entity cache hits: %d (expected %d)%n", eventCacheStats.getHitCount(), 1);
+
+         // Add a fictional delay so that there's a small enough gap for the
+         // query result set timestamp to be later in time than the update timestamp.
+         // Deleting an entity triggers an invalidation event which updates the timestamp.
+         Thread.sleep(100);
+
+         // Query entities, expect:
+         // * no cache hits since query is not cached
+         // * a query cache miss and query cache put
+         queryEntities();
+         stats = getStatistics();
+         printfAssert("Query cache miss: %d (expected %d)%n", stats.getQueryCacheMissCount(), 1);
+         printfAssert("Query cache put: %d (expected %d)%n", stats.getQueryCachePutCount(), 1);
+
+         // Repeat query, expect:
+         // * two cache hits for the number of entities in cache
+         // * a query cache hit
+         queryEntities();
+         stats = getStatistics();
+         printfAssert("Event entity cache hits: %d (expected %d)%n", stats.getSecondLevelCacheHitCount(), 2);
+         printfAssert("Query cache hit: %d (expected %d)%n", stats.getQueryCacheHitCount(), 1);
+
+         // Update one of the persisted entities, stats should show a cache hit and a cache put
+         updateEntity(2L);
+         eventCacheStats = getCacheStatistics(Event.class.getName());
+         printfAssert("Event entity cache hits: %d (expected %d)%n", eventCacheStats.getHitCount(), 1);
+         printfAssert("Event entity cache puts: %d (expected %d)%n", eventCacheStats.getPutCount(), 1);
+
+         // Repeat query after update, expect:
+         // * no cache hits or puts since entities are already cached
+         // * a query cache miss and query cache put, because when an entity is updated,
+         //   any queries for that type are invalidated
+         queryEntities();
+         stats = getStatistics();
+         printfAssert("Query cache miss: %d (expected %d)%n", stats.getQueryCacheMissCount(),1);
+         printfAssert("Query cache put: %d (expected %d)%n", stats.getQueryCachePutCount(), 1);
+
+
+         // Save cache-expiring entity, stats should show a second level cache put
+         saveExpiringEntity();
+         personCacheStats = getCacheStatistics(Person.class.getName());
+         printfAssert("Person entity cache puts: %d (expected %d)%n", personCacheStats.getPutCount(), 1);
+
+         // Find expiring entity, stats should show a second level cache hit
+         findExpiringEntity(4L);
+         personCacheStats = getCacheStatistics(Person.class.getName());
+         printfAssert("Person entity cache hits: %d (expected %d)%n", personCacheStats.getHitCount(), 1);
+
+         // Wait long enough for entity to be expired from cache
+         Thread.sleep(1100);
+
+         // Find expiring entity, after expiration entity should come from DB
+         // Stats should show a cache miss and a cache put
+         findExpiringEntity(4L);
+         personCacheStats = getCacheStatistics(Person.class.getName());
+         printfAssert("Person entity cache miss: %d (expected %d)%n", personCacheStats.getMissCount(), 1);
+         printfAssert("Person entity cache put: %d (expected %d)%n", personCacheStats.getPutCount(), 1);
+      };
+   }
+
+   private void persistEntities() {
+      try (Session em = createEntityManagerWithStatsCleared()) {
+         EntityTransaction tx = em.getTransaction();
+         try {
+            tx.begin();
+
+            em.persist(new Event("Caught a pokemon!"));
+            em.persist(new Event("Hatched an egg"));
+            em.persist(new Event("Became a gym leader"));
+         } catch (Throwable t) {
+            tx.setRollbackOnly();
+            throw t;
+         } finally {
+            if (tx.isActive()) tx.commit();
+            else tx.rollback();
+         }
+      }
+   }
+
+   private void findEntity(long id) {
+      try (Session em = createEntityManagerWithStatsCleared()) {
+         Event event = em.find(Event.class, id);
+         log.info(String.format("Found entity: %s", event));
+      }
+   }
+
+   private void updateEntity(long id) {
+      try (Session em = createEntityManagerWithStatsCleared()) {
+         EntityTransaction tx = em.getTransaction();
+         try {
+            tx.begin();
+
+            Event event = em.find(Event.class, id);
+            event.setName("Caught a Snorlax!!");
+
+            log.info(String.format("Updated entity: %s", event));
+         } catch (Throwable t) {
+            tx.setRollbackOnly();
+            throw t;
+         } finally {
+            if (tx.isActive()) tx.commit();
+            else tx.rollback();
+         }
+      }
+   }
+
+   private void evictEntity(long id) {
+      try (Session em = createEntityManagerWithStatsCleared()) {
+         em.getEntityManagerFactory().getCache().evict(Event.class, id);
+      }
+   }
+
+   private void deleteEntity(long id) {
+      try (Session em = createEntityManagerWithStatsCleared()) {
+         EntityTransaction tx = em.getTransaction();
+         try {
+            tx.begin();
+
+            Event event = em.find(Event.class, id);
+            em.remove(event);
+         } catch (Throwable t) {
+            tx.setRollbackOnly();
+            throw t;
+         } finally {
+            if (tx.isActive()) tx.commit();
+            else tx.rollback();
+         }
+      }
+   }
+
+   private void queryEntities() {
+      try (Session em = createEntityManagerWithStatsCleared()) {
+         TypedQuery<Event> query = em.createQuery("from Event", Event.class);
+         query.setHint("org.hibernate.cacheable", Boolean.TRUE);
+         List<Event> events = query.getResultList();
+         log.info(String.format("Queried events: %s%n", events));
+      }
+   }
+
+   private void saveExpiringEntity() {
+      try (Session em = createEntityManagerWithStatsCleared()) {
+         EntityTransaction tx = em.getTransaction();
+         try {
+            tx.begin();
+
+            em.persist(new Person("Satoshi"));
+         } catch (Throwable t) {
+            tx.setRollbackOnly();
+            throw t;
+         } finally {
+            if (tx.isActive()) tx.commit();
+            else tx.rollback();
+         }
+      }
+   }
+
+   private void findExpiringEntity(long id) {
+      try (Session em = createEntityManagerWithStatsCleared()) {
+         Person person = em.find(Person.class, id);
+         System.out.printf("Found expiring entity: %s%n", person);
+      }
+   }
+
+   private Session createEntityManagerWithStatsCleared() {
+      EntityManager em = emf.createEntityManager();
+      emf.unwrap(SessionFactory.class).getStatistics().clear();
+      // JPA's EntityManager is not AutoCloseable,
+      // but Hibernate's Session is,
+      // so unwrap it to make it easier to close after use.
+      return em.unwrap(Session.class);
+   }
+
+   private SecondLevelCacheStatistics getCacheStatistics(String regionName) {
+      return emf.unwrap(SessionFactory.class).getStatistics()
+         .getSecondLevelCacheStatistics(regionName);
+   }
+
+   private Statistics getStatistics() {
+      return emf.unwrap(SessionFactory.class).getStatistics();
+   }
+
+   private static void printfAssert(String format, long actual, long expected) {
+      log.info(String.format(format, actual, expected));
+      if (expected != actual) {
+         throw new AssertionError("Expected: " + expected + ", actual: " + actual);
+      }
+   }
+
+   public static void main(String[] args) {
+      SpringApplication.run(InfinispanHibernateCacheSpringLocal.class);
+   }
+
+}

--- a/hibernate-cache/spring-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/spring/local/model/Event.java
+++ b/hibernate-cache/spring-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/spring/local/model/Event.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.infinispan.tutorial.simple.hibernate.cache.spring.local.model;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import java.time.LocalDateTime;
+
+@Entity
+@Cacheable
+public class Event {
+
+   @Id
+   @GeneratedValue
+   private Long id;
+
+   private String name;
+
+   private LocalDateTime timestamp = LocalDateTime.now();
+
+   public Event(String name) {
+      this.name = name;
+   }
+
+   public Event() {
+   }
+
+   public Long getId() {
+      return id;
+   }
+
+   public void setId(Long id) {
+      this.id = id;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   public LocalDateTime getTimestamp() {
+      return timestamp;
+   }
+
+   public void setTimestamp(LocalDateTime timestamp) {
+      this.timestamp = timestamp;
+   }
+
+   @Override
+   public String toString() {
+      return "Event{" +
+            "id=" + id +
+            ", name='" + name + '\'' +
+            ", time=" + timestamp +
+            '}';
+   }
+
+}

--- a/hibernate-cache/spring-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/spring/local/model/Person.java
+++ b/hibernate-cache/spring-local/src/main/java/org/infinispan/tutorial/simple/hibernate/cache/spring/local/model/Person.java
@@ -1,0 +1,48 @@
+package org.infinispan.tutorial.simple.hibernate.cache.spring.local.model;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@Cacheable
+public class Person {
+
+   @Id
+   @GeneratedValue
+   private Long id;
+   private String name;
+
+   public Person(String name) {
+      this.name = name;
+   }
+
+   public Person() {
+   }
+
+   public Long getId() {
+      return id;
+   }
+
+   public void setId(Long id) {
+      this.id = id;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String firstName) {
+      this.name = firstName;
+   }
+
+   @Override
+   public String toString() {
+      return "Person{" +
+            "id=" + id +
+            ", name='" + name + '\'' +
+            '}';
+   }
+
+}

--- a/hibernate-cache/spring-local/src/main/resources/application.properties
+++ b/hibernate-cache/spring-local/src/main/resources/application.properties
@@ -1,0 +1,21 @@
+# Enable those entities marked with @Cacheable to be cached
+spring.jpa.properties.javax.persistence.sharedCache.mode=ENABLE_SELECTIVE
+# Enables second level cache
+spring.jpa.properties.hibernate.cache.use_second_level_cache=true
+# Enable query cache
+spring.jpa.properties.hibernate.cache.use_query_cache=true
+
+# Use Infinispan second level cache provider
+spring.jpa.properties.hibernate.cache.region.factory_class=infinispan
+# Force using local configuration when only using a single node.
+# Otherwise a clustered configuration is loaded.
+spring.jpa.properties.hibernate.cache.infinispan.cfg=org/infinispan/hibernate/cache/commons/builder/infinispan-configs-local.xml
+
+# Entity specific configuration, e.g. via property:
+#   hibernate.cache.infinispan.<Entity FQN>.expiration.max_idle
+spring.jpa.properties.hibernate.cache.infinispan.org.infinispan.tutorial.simple.hibernate.cache.spring.local.model.Person.expiration.max_idle=1000
+
+# Generate statistics to see effects of second level cache
+spring.jpa.properties.hibernate.generate_statistics=true
+# Make session metrics/statistics logging less noisy
+logging.level.org.hibernate.engine.internal.StatisticalLoggingSessionEventListener=ERROR

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
        <module>counter</module>
        <module>hibernate-cache/local</module>
        <module>hibernate-cache/wildfly-local</module>
+       <module>hibernate-cache/spring-local</module>
     </modules>
 </project>
 


### PR DESCRIPTION
Part of http://issues.jboss.org/browse/ISPN-8024

It uses 9.2.0-SNAPSHOT until next release of 9.2.x where two Hibernate Cache providers have been implemented for Hibernate 5.2 and 5.1 respectively. This demo uses Hibernate 5.2, so it uses the correct cache provider for that version.