### PR TITLE
Add simple tutorial for server tasks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
        <module>hibernate-cache/local</module>
        <module>hibernate-cache/wildfly-local</module>
        <module>hibernate-cache/spring-local</module>
+       <module>server-tasks</module>
     </modules>
 </project>
 

--- a/server-tasks/pom.xml
+++ b/server-tasks/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+   <artifactId>infinispan-simple-tutorials-server-tasks</artifactId>
+   <parent>
+      <relativePath>../pom.xml</relativePath>
+      <version>1.0.0-SNAPSHOT</version>
+      <groupId>org.infinispan.tutorial.simple</groupId>
+      <artifactId>infinispan-simple-tutorials</artifactId>
+   </parent>
+   <name>Infinispan Simple Tutorials: Server Tasks</name>
+
+   <properties>
+      <version.wildfly.maven.plugin>1.2.0.Beta1</version.wildfly.maven.plugin>
+   </properties>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-maven-plugin</artifactId>
+            <version>${version.wildfly.maven.plugin}</version>
+         </plugin>
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <goals>
+                     <goal>exec</goal>
+                  </goals>
+               </execution>
+            </executions>
+            <configuration>
+               <executable>java</executable>
+               <arguments>
+                  <argument>-Djava.net.preferIPv4Stack=true</argument>
+                  <argument>-Djava.util.logging.config.file=src/main/resources/logging.properties</argument>
+                  <argument>-classpath</argument>
+                  <classpath />
+                  <argument>org.infinispan.tutorial.simple.server.tasks.InfinispanServerTasks</argument>
+               </arguments>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-client-hotrod</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-tasks-api</artifactId>
+      </dependency>
+   </dependencies>
+
+</project>

--- a/server-tasks/src/main/java/org/infinispan/tutorial/simple/server/tasks/InfinispanServerTasks.java
+++ b/server-tasks/src/main/java/org/infinispan/tutorial/simple/server/tasks/InfinispanServerTasks.java
@@ -1,0 +1,52 @@
+package org.infinispan.tutorial.simple.server.tasks;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.tasks.ServerTask;
+import org.infinispan.tasks.TaskContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class InfinispanServerTasks {
+
+   public static void main(String[] args) {
+      // Create a configuration for a locally-running server
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.addServer().host("127.0.0.1").port(11222);
+      // Connect to the server
+      RemoteCacheManager cacheManager = new RemoteCacheManager(builder.build());
+      // Obtain the remote cache
+      RemoteCache<String, String> cache = cacheManager.getCache();
+      // Create task parameters
+      Map<String, String> parameters = new HashMap<>();
+      parameters.put("name", "developer");
+      // Execute task
+      String greet = cache.execute("hello-task", parameters);
+      System.out.printf("Greeting = %s\n", greet);
+   }
+
+   public static class HelloTask implements ServerTask<String> {
+
+      private TaskContext ctx;
+
+      @Override
+      public void setTaskContext(TaskContext ctx) {
+         this.ctx = ctx;
+      }
+
+      @Override
+      public String call() throws Exception {
+         String name = (String) ctx.getParameters().get().get("name");
+         return "Hello " + name;
+      }
+
+      @Override
+      public String getName() {
+         return "hello-task";
+      }
+
+   }
+
+}

--- a/server-tasks/src/main/java/org/infinispan/tutorial/simple/server/tasks/InfinispanServerTasks.java
+++ b/server-tasks/src/main/java/org/infinispan/tutorial/simple/server/tasks/InfinispanServerTasks.java
@@ -25,6 +25,8 @@ public class InfinispanServerTasks {
       // Execute task
       String greet = cache.execute("hello-task", parameters);
       System.out.printf("Greeting = %s\n", greet);
+      // Stop the cache manager and release all resources
+      cacheManager.stop();
    }
 
    public static class HelloTask implements ServerTask<String> {

--- a/server-tasks/src/main/java/org/infinispan/tutorial/simple/server/tasks/InfinispanServerTasks.java
+++ b/server-tasks/src/main/java/org/infinispan/tutorial/simple/server/tasks/InfinispanServerTasks.java
@@ -1,30 +1,51 @@
 package org.infinispan.tutorial.simple.server.tasks;
 
+import org.infinispan.Cache;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.commons.dataconversion.UTF8Encoder;
+import org.infinispan.commons.marshall.UTF8StringMarshaller;
 import org.infinispan.tasks.ServerTask;
 import org.infinispan.tasks.TaskContext;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class InfinispanServerTasks {
 
    public static void main(String[] args) {
       // Create a configuration for a locally-running server
       ConfigurationBuilder builder = new ConfigurationBuilder();
-      builder.addServer().host("127.0.0.1").port(11222);
+      builder
+         .addServer().host("127.0.0.1").port(11222)
+         .marshaller(UTF8StringMarshaller.class); // Data is UTF-8 String encoded
+
       // Connect to the server
       RemoteCacheManager cacheManager = new RemoteCacheManager(builder.build());
+
       // Obtain the remote cache
       RemoteCache<String, String> cache = cacheManager.getCache();
+
       // Create task parameters
       Map<String, String> parameters = new HashMap<>();
       parameters.put("name", "developer");
-      // Execute task
+
+      // Execute hello task
       String greet = cache.execute("hello-task", parameters);
       System.out.printf("Greeting = %s\n", greet);
+
+      // Store some values and compute the sum
+      int range = 10;
+      IntStream.range(0, range).boxed().forEach(
+         i -> cache.put(i + "-key", i + "-value")
+      );
+      int result = cache.execute("sum-values-task", Collections.emptyMap());
+      System.out.printf("Sum of values = %d\n", result);
+
       // Stop the cache manager and release all resources
       cacheManager.stop();
    }
@@ -47,6 +68,38 @@ public class InfinispanServerTasks {
       @Override
       public String getName() {
          return "hello-task";
+      }
+
+   }
+
+   public static class SumValuesTask implements ServerTask<Integer> {
+
+      private TaskContext ctx;
+
+      @Override
+      public void setTaskContext(TaskContext ctx) {
+         this.ctx = ctx;
+      }
+
+      @Override
+      public Integer call() throws Exception {
+         Cache<String, String> cache = getCache();
+
+         return cache.keySet()
+            .stream()
+               .map(e -> Integer.valueOf(e.substring(0, e.indexOf("-"))))
+               .collect(() -> Collectors.summingInt(Integer::intValue));
+      }
+
+      @Override
+      public String getName() {
+         return "sum-values-task";
+      }
+
+      @SuppressWarnings("unchecked")
+      private Cache<String, String> getCache() {
+         return (Cache<String, String>) ctx.getCache().get()
+            .getAdvancedCache().withEncoding(UTF8Encoder.class);
       }
 
    }

--- a/server-tasks/src/main/resources/META-INF/services/org.infinispan.tasks.ServerTask
+++ b/server-tasks/src/main/resources/META-INF/services/org.infinispan.tasks.ServerTask
@@ -1,0 +1,1 @@
+org.infinispan.tutorial.simple.server.tasks.InfinispanServerTasks$HelloTask

--- a/server-tasks/src/main/resources/META-INF/services/org.infinispan.tasks.ServerTask
+++ b/server-tasks/src/main/resources/META-INF/services/org.infinispan.tasks.ServerTask
@@ -1,1 +1,2 @@
 org.infinispan.tutorial.simple.server.tasks.InfinispanServerTasks$HelloTask
+org.infinispan.tutorial.simple.server.tasks.InfinispanServerTasks$SumValuesTask

--- a/testAll.sh
+++ b/testAll.sh
@@ -56,6 +56,10 @@ read -p "Start Infinispan Server, press any key when ready..."
 runTestAndExitOnError remote
 runTestAndExitOnError remote-listen
 runTestAndExitOnError scripting
+cd server-tasks
+mvn clean package wildfly:deploy
+cd ..
+runTestAndExitOnError server-tasks
 
 # npm should be installed
 echo "NPM should be installed"


### PR DESCRIPTION
Task execution cache and data manipulation cache currently require remote cache managers configured differently (see [ISPN-8814](https://issues.jboss.org/browse/ISPN-8814) and [related ISPN-8815](https://issues.jboss.org/browse/ISPN-8815)).

The example shows two cases:
* A simple task that does not access cache but takes parameters.
* A task that access the cache, calculates a result using embedded Java streams and returns result.