### PR TITLE
Update Hibernate cache examples

### DIFF
--- a/hibernate-cache/local/pom.xml
+++ b/hibernate-cache/local/pom.xml
@@ -12,7 +12,7 @@
    <name>Infinispan Simple Tutorials: Hibernate Cache Local</name>
 
    <properties>
-      <version.hibernate-core>5.3.0.CR2</version.hibernate-core>
+      <version.hibernate-core>5.3.4.Final</version.hibernate-core>
       <version.h2>1.3.176</version.h2>
       <version.log4j>2.8.1</version.log4j>
    </properties>

--- a/hibernate-cache/spring-local/pom.xml
+++ b/hibernate-cache/spring-local/pom.xml
@@ -12,13 +12,13 @@
    <parent>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-parent</artifactId>
-      <version>2.0.0.M7</version>
+      <version>2.0.4.RELEASE</version>
    </parent>
 
    <properties>
       <java.version>1.8</java.version>
 
-      <!-- TODO remove when Spring Boot supports Hibernate 5.3/Infinispan 5.3 -->
+      <!-- TODO remove when Spring Boot (coming in 2.1) supports Hibernate 5.3/Infinispan 5.3 -->
       <version.infinispan>9.2.5.Final</version.infinispan>
    </properties>
 
@@ -44,13 +44,28 @@
          <artifactId>h2</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.infinispan</groupId>
-         <artifactId>infinispan-hibernate-cache</artifactId>
-      </dependency>
-      <dependency>
          <groupId>org.springframework.boot</groupId>
          <artifactId>spring-boot-starter-test</artifactId>
          <scope>test</scope>
+      </dependency>
+
+      <!-- TODO remove when Spring Boot (coming in 2.1) supports Hibernate 5.3/Infinispan 5.3 -->
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-hibernate-cache</artifactId>
+         <version>${version.infinispan}</version>
+      </dependency>
+      <!-- TODO remove when Spring Boot (coming in 2.1) supports Hibernate 5.3/Infinispan 5.3 -->
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-core</artifactId>
+         <version>${version.infinispan}</version>
+      </dependency>
+      <!-- TODO remove when Spring Boot (coming in 2.1) supports Hibernate 5.3/Infinispan 5.3 -->
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-commons</artifactId>
+         <version>${version.infinispan}</version>
       </dependency>
    </dependencies>
 


### PR DESCRIPTION
Spring Boot 2.0 still relies on Hibernate 5.2, so adjusted example to support that.