### PR TITLE
ISPN-9554 Align spring-boot supported version with RHOAR

### DIFF
--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -14,8 +14,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring-boot.version>2.0.3.RELEASE</spring-boot.version>
-        <infinispan.starters.version>2.0.0.Beta2</infinispan.starters.version>
+        <spring-boot.version>1.5.16.RELEASE</spring-boot.version>
+        <infinispan.starters.version>1.0.1.Final</infinispan.starters.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9554

I released now infinispan-spring-boot-starter 1.0.1.Final with Spring boot 1.5.6 version