### PR TITLE
Use keytool from JAVA_HOME if available

### DIFF
--- a/infinispan-remote/security/tls-authorization/create_signed_certificates.sh
+++ b/infinispan-remote/security/tls-authorization/create_signed_certificates.sh
@@ -1,45 +1,55 @@
+#!/bin/bash
+
+if [ -f ${JAVA_HOME}/bin/keytool ] ; then
+  # Maven uses JAVA_HOME to compile the project. If keytool bin is there, use it instead
+  KEYTOOL_CMD="${JAVA_HOME}/bin/keytool"
+else
+  # Otherwise, uses the keytool defined in path.
+  KEYTOOL_CMD="keytool"
+fi
+
 # Generate a CA certificate so that clients can trust server certificates
-keytool -genkeypair -validity 365 -keyalg RSA -keysize 2048 -storetype PKCS12 -alias ca -dname "CN=CA,OU=Infinispan,O=JBoss,L=Red Hat" -storepass CAsecret -keystore ca.p12 -ext bc:c
+${KEYTOOL_CMD} -genkeypair -validity 365 -keyalg RSA -keysize 2048 -storetype PKCS12 -alias ca -dname "CN=CA,OU=Infinispan,O=JBoss,L=Red Hat" -storepass CAsecret -keystore ca.p12 -ext bc:c
 # Extract the CA certificate to a file that you can import into other stores
-keytool -exportcert -alias ca -keystore ca.p12 -storepass CAsecret -file ca.cer
+${KEYTOOL_CMD} -exportcert -alias ca -keystore ca.p12 -storepass CAsecret -file ca.cer
 
 
 # Generate the server certificate
-keytool -genkeypair -validity 365 -keyalg RSA -keysize 2048 -storetype PKCS12 -alias infinispan-server -dname "CN=Server,OU=Infinispan,O=JBoss,L=Red Hat" -storepass Serversecret -keystore server_keystore.p12
+${KEYTOOL_CMD} -genkeypair -validity 365 -keyalg RSA -keysize 2048 -storetype PKCS12 -alias infinispan-server -dname "CN=Server,OU=Infinispan,O=JBoss,L=Red Hat" -storepass Serversecret -keystore server_keystore.p12
 # Create a Certificate Signing Request (CSR) for the server certificate
-keytool -certreq -alias infinispan-server -keystore server_keystore.p12 -storepass Serversecret -file server.csr
+${KEYTOOL_CMD} -certreq -alias infinispan-server -keystore server_keystore.p12 -storepass Serversecret -file server.csr
 # Sign the server CSR with the CA
-keytool -gencert -keystore ca.p12 -alias ca -infile server.csr -outfile server.cer -storepass CAsecret
+${KEYTOOL_CMD} -gencert -keystore ca.p12 -alias ca -infile server.csr -outfile server.cer -storepass CAsecret
 # Import the CA certificate into the server keystore
 # This is required because the keystore needs the full certificate chain
-keytool -importcert -alias ca -keystore server_keystore.p12 -file ca.cer -storepass Serversecret -noprompt
+${KEYTOOL_CMD} -importcert -alias ca -keystore server_keystore.p12 -file ca.cer -storepass Serversecret -noprompt
 # Import the signed certificate back into the server keystore
-keytool -importcert -alias infinispan-server -keystore server_keystore.p12 -file server.cer -storepass Serversecret -noprompt
+${KEYTOOL_CMD} -importcert -alias infinispan-server -keystore server_keystore.p12 -file server.cer -storepass Serversecret -noprompt
 
 # Create a server trust store that contains the CA
-keytool -importcert -alias ca -keystore server_truststore.p12 -storepass ServerTrustsecret -file ca.cer -noprompt
+${KEYTOOL_CMD} -importcert -alias ca -keystore server_truststore.p12 -storepass ServerTrustsecret -file ca.cer -noprompt
 
 # Generate the first client certificate
-keytool -genkeypair -validity 365 -keyalg RSA -keysize 2048 -alias client1 -dname "CN=Client1,OU=Infinispan,O=JBoss,L=Red Hat" -storepass Client1secret -keystore client1_keystore.p12
+${KEYTOOL_CMD} -genkeypair -validity 365 -keyalg RSA -keysize 2048 -alias client1 -dname "CN=Client1,OU=Infinispan,O=JBoss,L=Red Hat" -storepass Client1secret -keystore client1_keystore.p12
 # Create a Certificate Signing Request (CSR) for the client certificate
-keytool -certreq -alias client1 -keystore client1_keystore.p12 -storepass Client1secret -file client1.csr
+${KEYTOOL_CMD} -certreq -alias client1 -keystore client1_keystore.p12 -storepass Client1secret -file client1.csr
 # Sign the client CSR with the CA
-keytool -gencert -keystore ca.p12 -alias ca -infile client1.csr -outfile client1.cer -storepass CAsecret
+${KEYTOOL_CMD} -gencert -keystore ca.p12 -alias ca -infile client1.csr -outfile client1.cer -storepass CAsecret
 # Import the CA certificate into the client keystore
 # This is required because the keystore needs the full certificate chain
-keytool -importcert -alias ca -keystore client1_keystore.p12 -file ca.cer -storepass Client1secret -noprompt
+${KEYTOOL_CMD} -importcert -alias ca -keystore client1_keystore.p12 -file ca.cer -storepass Client1secret -noprompt
 # Import the signed certificate back into the client keystore
-keytool -importcert -alias client1 -keystore client1_keystore.p12 -file client1.cer -storepass Client1secret -noprompt
+${KEYTOOL_CMD} -importcert -alias client1 -keystore client1_keystore.p12 -file client1.cer -storepass Client1secret -noprompt
 
 
 # Generate the second client certificate
-keytool -genkeypair -validity 365 -keyalg RSA -keysize 2048 -alias client2 -dname "CN=Client2,OU=Infinispan,O=JBoss,L=Red Hat" -storepass Client2secret -keystore client2_keystore.p12
+${KEYTOOL_CMD} -genkeypair -validity 365 -keyalg RSA -keysize 2048 -alias client2 -dname "CN=Client2,OU=Infinispan,O=JBoss,L=Red Hat" -storepass Client2secret -keystore client2_keystore.p12
 # Create a Certificate Signing Request (CSR) for the client certificate
-keytool -certreq -alias client2 -keystore client2_keystore.p12 -storepass Client2secret -file client2.csr
+${KEYTOOL_CMD} -certreq -alias client2 -keystore client2_keystore.p12 -storepass Client2secret -file client2.csr
 # Sign the client CSR with the CA
-keytool -gencert -keystore ca.p12 -alias ca -infile client2.csr -outfile client2.cer -storepass CAsecret
+${KEYTOOL_CMD} -gencert -keystore ca.p12 -alias ca -infile client2.csr -outfile client2.cer -storepass CAsecret
 # Import the CA certificate into the client keystore
 # This is required because the keystore needs the full certificate chain 
-keytool -importcert -alias ca -keystore client2_keystore.p12 -file ca.cer -storepass Client2secret -noprompt
+${KEYTOOL_CMD} -importcert -alias ca -keystore client2_keystore.p12 -file ca.cer -storepass Client2secret -noprompt
 # Import the signed certificate back into the client keystore
-keytool -importcert -alias client2 -keystore client2_keystore.p12 -file client2.cer -storepass Client2secret -noprompt
+${KEYTOOL_CMD} -importcert -alias client2 -keystore client2_keystore.p12 -file client2.cer -storepass Client2secret -noprompt

--- a/infinispan-remote/security/tls-authorization/create_signed_server_truststore_auth.sh
+++ b/infinispan-remote/security/tls-authorization/create_signed_server_truststore_auth.sh
@@ -1,8 +1,18 @@
+#!/bin/bash
+
+if [ -f ${JAVA_HOME}/bin/keytool ] ; then
+  # Maven uses JAVA_HOME to compile the project. If keytool bin is there, use it instead
+  KEYTOOL_CMD="${JAVA_HOME}/bin/keytool"
+else
+  # Otherwise, uses the keytool defined in path.
+  KEYTOOL_CMD="keytool"
+fi
+
 # First create a server trust store using create-signed_certificates.sh
 # Make a copy of the server trust store
 cp server_truststore.p12 server_truststoreAuth.p12
 
 # Import the client certificate into the server trust store
 # This is necessary if you use client certificate authentication
-keytool -importcert -alias client1 -keystore server_truststoreAuth.p12 -file client1.cer -storepass ServerTrustsecret -noprompt
-keytool -importcert -alias client2 -keystore server_truststoreAuth.p12 -file client2.cer -storepass ServerTrustsecret -noprompt
+${KEYTOOL_CMD} -importcert -alias client1 -keystore server_truststoreAuth.p12 -file client1.cer -storepass ServerTrustsecret -noprompt
+${KEYTOOL_CMD} -importcert -alias client2 -keystore server_truststoreAuth.p12 -file client2.cer -storepass ServerTrustsecret -noprompt

--- a/infinispan-remote/security/tls-authorization/create_unsigned_certificates.sh
+++ b/infinispan-remote/security/tls-authorization/create_unsigned_certificates.sh
@@ -1,22 +1,32 @@
+#!/bin/bash
+
+if [ -f ${JAVA_HOME}/bin/keytool ] ; then
+  # Maven uses JAVA_HOME to compile the project. If keytool bin is there, use it instead
+  KEYTOOL_CMD="${JAVA_HOME}/bin/keytool"
+else
+  # Otherwise, uses the keytool defined in path.
+  KEYTOOL_CMD="keytool"
+fi
+
 # Create a basic keystore with PKCS12
 # Use rhdg-server as the alias and 'secret' as the password
-keytool -genkeypair -alias infinispan-server -keystore server-keystore.pfx -keyalg RSA -dname "CN=Server,OU=Infinispan,O=JBoss,L=Red Hat" -storepass secret -validity 365 -keysize 4096
+${KEYTOOL_CMD} -genkeypair -alias infinispan-server -keystore server-keystore.pfx -keyalg RSA -dname "CN=Server,OU=Infinispan,O=JBoss,L=Red Hat" -storepass secret -validity 365 -keysize 4096
 # Export the self-signed certificate
-keytool -exportcert -alias infinispan-server -file server-cert.cer -keystore server-keystore.pfx -storepass secret
+${KEYTOOL_CMD} -exportcert -alias infinispan-server -file server-cert.cer -keystore server-keystore.pfx -storepass secret
 # Import the certificate to a client trust store
 # Use 'trustSecret' as the password for the client trust store
-keytool -import -v -trustcacerts -alias infinispan-server -file server-cert.cer -keystore server-truststore.pfx -storepass trustSecret -noprompt
+${KEYTOOL_CMD} -import -v -trustcacerts -alias infinispan-server -file server-cert.cer -keystore server-truststore.pfx -storepass trustSecret -noprompt
 
 # Generate the first client certificate
-keytool -genkeypair -alias client1 -keystore client1-keystore.pfx -storepass Client1secret -dname "CN=Client1,OU=Infinispan,O=JBoss,L=Red Hat" -validity 365 -keyalg RSA -keysize 2048
+${KEYTOOL_CMD} -genkeypair -alias client1 -keystore client1-keystore.pfx -storepass Client1secret -dname "CN=Client1,OU=Infinispan,O=JBoss,L=Red Hat" -validity 365 -keyalg RSA -keysize 2048
 # Export the self-signed certificate
-keytool -exportcert -alias client1 -file client1.cer -keystore client1-keystore.pfx -storepass Client1secret
+${KEYTOOL_CMD} -exportcert -alias client1 -file client1.cer -keystore client1-keystore.pfx -storepass Client1secret
 # Import the signed certificate to a trust store
-keytool -importcert -alias client1 -keystore client-truststore.pfx -file client1.cer -storepass ClientSecret -noprompt
+${KEYTOOL_CMD} -importcert -alias client1 -keystore client-truststore.pfx -file client1.cer -storepass ClientSecret -noprompt
 
 # Generate the second client certificate
-keytool -genkeypair -alias client2 -keystore client2-keystore.pfx -storepass Client2secret -dname "CN=Client2,OU=Infinispan,O=JBoss,L=Red Hat" -validity 365 -keyalg RSA -keysize 2048
+${KEYTOOL_CMD} -genkeypair -alias client2 -keystore client2-keystore.pfx -storepass Client2secret -dname "CN=Client2,OU=Infinispan,O=JBoss,L=Red Hat" -validity 365 -keyalg RSA -keysize 2048
 # Export the self-signed certificate
-keytool -exportcert -alias client2 -file client2.cer -keystore client2-keystore.pfx -storepass Client2secret
+${KEYTOOL_CMD} -exportcert -alias client2 -file client2.cer -keystore client2-keystore.pfx -storepass Client2secret
 # Import the signed certificate to a trust store
-keytool -importcert -alias client2 -keystore client-truststore.pfx -file client2.cer -storepass ClientSecret -noprompt
+${KEYTOOL_CMD} -importcert -alias client2 -keystore client-truststore.pfx -file client2.cer -storepass ClientSecret -noprompt


### PR DESCRIPTION
Downstream, we use JAVA_HOME to set the JDK to use and Maven uses it as
well to compile; old keytool version (Java 8) blocks waiting for
user input which fails the downstream Jenkins jobs.