### PR TITLE
docs updates for Infinispan 14, fix broken urls  #169

### DIFF
--- a/documentation/asciidoc/topics/attributes/community-attributes.adoc
+++ b/documentation/asciidoc/topics/attributes/community-attributes.adoc
@@ -3,7 +3,7 @@
 :tutorials: Code Tutorials
 :repository: https://github.com/infinispan/infinispan-simple-tutorials/tree/main
 :repository_ssh: git@github.com:infinispan/infinispan-simple-tutorials.git
-:operator: https://infinispan.org/docs/infinispan-operator/
+:k8s_docs: https://infinispan.org/docs/infinispan-operator/main/operator.html
 :download_url: https://infinispan.org/download/
 
 :plusplus: ++
@@ -22,9 +22,6 @@
 
 //CLI
 :cli_docs: {stable_documentation}/cli/cli.html
-
-//Dev
-:dev_docs: {stable_documentation}/developing/developing.html
 
 //Embedded
 :library_docs: {stable_documentation}/embedding/embedding.html

--- a/documentation/asciidoc/topics/attributes/downstream-attributes.adoc
+++ b/documentation/asciidoc/topics/attributes/downstream-attributes.adoc
@@ -1,3 +1,3 @@
 :tutorials: Code Tutorials
-:repository: https://github.com/redhat-developer/redhat-datagrid-tutorials/tree/RHDG_8.3.0
+:repository: https://github.com/redhat-developer/redhat-datagrid-tutorials/tree/RHDG_8.4.0
 :repository_ssh: git@github.com:redhat-developer/redhat-datagrid-tutorials.git

--- a/documentation/asciidoc/topics/ref_cross_site_replication.adoc
+++ b/documentation/asciidoc/topics/ref_cross_site_replication.adoc
@@ -35,7 +35,7 @@ Make sure you have `minikube` installed locally.
 ====
 
 .Steps
-. Run *`./setup.sh`*: This script starts minikube, installs the Infinispan Operator, deploys two clusters (LON and NYC) and creates the caches.
+. Run *`./setup.sh`*: This script starts minikube, installs the {brandname} Operator, deploys two clusters (LON and NYC) and creates the caches.
 . Run *`./create-data.sh`*
 
 Both sites are accessible externally using the {brandname} Console through
@@ -54,4 +54,4 @@ To go further use the {brandname} Console or the REST API, add launch additional
 .Additional resources
 * link:{xsite_docs}[Cross-Site Replication Guide]
 * link:{rest_docs}#rest_v2_cache_operations[REST API: Cross-Site Replication]
-* link:{operator}[{brandname} Operator]
+* link:{k8s_docs}[{brandname} Operator]

--- a/documentation/asciidoc/topics/ref_embedded_tutorials.adoc
+++ b/documentation/asciidoc/topics/ref_embedded_tutorials.adoc
@@ -69,5 +69,4 @@ endif::community[]
 You can find more resources about embedded caches in our documentation at:
 
 * link:{library_docs}[Embedding {brandname} Caches]
-* link:{dev_docs}[{brandname} Developer Guide]
 * link:{query_docs}[Querying {brandname} caches]

--- a/documentation/asciidoc/topics/ref_hibernate_tutorials.adoc
+++ b/documentation/asciidoc/topics/ref_hibernate_tutorials.adoc
@@ -38,5 +38,5 @@ $ {wildfly_deploy}
 
 You can find more resources in our documentation at:
 
-* link:{dev_docs}#ispn_modules[{brandname} WildFly modules]
+* link:{library_docs}#ispn_modules[{brandname} WildFly modules]
 * link:{hibernate_docs}[Hibernate Second-Level Caching]

--- a/documentation/asciidoc/topics/ref_hotrod_cpp_tutorials.adoc
+++ b/documentation/asciidoc/topics/ref_hotrod_cpp_tutorials.adoc
@@ -5,7 +5,7 @@
 == Prerequisites
 
 * Centos 7 (RHEL 7 should work also)
-* Infinispan server running with the default standalone configuration
+* {brandname} Server running with the default standalone configuration
 
 [discrete]
 == Docker

--- a/documentation/asciidoc/topics/ref_hotrod_java_tutorials.adoc
+++ b/documentation/asciidoc/topics/ref_hotrod_java_tutorials.adoc
@@ -1,7 +1,7 @@
 [id='hotrod-java-tutorials_{context}']
 = Hot Rod Java client tutorials
 
-* Hot Rod Java clients require JDK 8 or later. However, {brandname} recommends using Java 11 at a minimum.
+* {brandname} requires Java 11 at a minimum. However, Hot Rod Java clients running in applications that require Java 8 can continue using older versions of client libraries.
 
 [%header,cols=2*]
 |===
@@ -70,6 +70,5 @@ You can find more resources for Hot Rod Java clients in our documentation at:
 * link:{hotrod_docs}[Hot Rod Java client guide]
 * link:{encoding_docs}[Marshalling and Encoding Data Guide]
 * link:{query_docs}[Querying {brandname} caches]
-* link:{dev_docs}[Developer guide]
 * link:{rest_docs}[REST API]
 * link:{resp_docs}[Resp Protocol]

--- a/documentation/asciidoc/topics/ref_hotrod_js_tutorials.adoc
+++ b/documentation/asciidoc/topics/ref_hotrod_js_tutorials.adoc
@@ -36,4 +36,4 @@ Create a cache named `my-cache` using the http://localhost:11222/[{brandname} Co
 node index.js
 ----
 
-Check with the Infinispan Console http://localhost:11222/console/my-cach[the `my-cache` cache detail].
+Check with the {brandname} Console http://localhost:11222/console/my-cach[the `my-cache` cache detail].

--- a/documentation/asciidoc/topics/ref_remote_tutorials.adoc
+++ b/documentation/asciidoc/topics/ref_remote_tutorials.adoc
@@ -21,7 +21,7 @@ $ ./bin/server.sh
 [NOTE]
 ====
 {brandname} Server enables authentication and authorization by default.
-Creating a user named `admin` gives you administrative access to Infinispan Server.
+Creating a user named `admin` gives you administrative access to {brandname} Server.
 ====
 
 .Building and running remote cache tutorials


### PR DESCRIPTION
Closes #169 

update urls that reference the Developer guide that was removed
Update repository url to point to 8.4.0
mention that Java 11 (at least) is a requirement now
fix broken link to the operator doc
fix link to the Infinispan Wildfly modules that were moved from Dev guide to the Embedded guide