### PR TITLE
Infinispan 15.0.3.Final

### DIFF
--- a/documentation/asciidoc/topics/ref_spring_tutorials.adoc
+++ b/documentation/asciidoc/topics/ref_spring_tutorials.adoc
@@ -11,18 +11,21 @@ These code tutorials use {brandname} Server and require at least one running ins
 Two simple tutorials can be run with Spring without Spring Boot:
 
 * Test caching
+
 [source,bash,options="nowrap",subs=attributes+]
 ----
 $ {package_exec}@spring-caching
 ----
 
 * Test annotations
+
 [source,bash,options="nowrap",subs=attributes+]
 ----
 $ {package_exec}@spring-annotations
 ----
 
-.Run Spring Boot examples
+To run the Spring Boot tutorials, use the following command.
+
 [source,bash,options="nowrap",subs=attributes+]
 ----
 $ {spring_boot_run}

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-build-configuration-parent</artifactId>
-        <version>15.0.2.Final</version>
+        <version>15.0.3.Final</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.infinispan.tutorial.simple</groupId>


### PR DESCRIPTION
The documentation for the spring tutorial is not properly generated: https://infinispan.org/tutorials/simple/simple_tutorials.html#spring-tutorials

It is fixed in this PR too. 