### PR TITLE
[#709] Harden GitHub Actions with top-level permissions and SHA pinning

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * 1-5'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -13,12 +16,12 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: development   # Force checkout of the dev branch
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -34,7 +37,7 @@ jobs:
         run: ./mvnw -B clean install -Dmaven.test.failure.ignore=true
 
       - name: Test Logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: success() || failure()
         with:
           name: jdk17-test-results
@@ -46,4 +49,4 @@ jobs:
 
       - name: Dump docker logs on failure
         if: failure()
-        uses: jwalton/gh-docker-logs@v2
+        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2

--- a/.github/workflows/guides.yml
+++ b/.github/workflows/guides.yml
@@ -5,12 +5,15 @@ on:
       branches:
          - main
 
+permissions:
+  contents: read
+
 jobs:
    publish:
       runs-on: ubuntu-latest
       steps:
          - name: Trigger website rebuild
-           uses: peter-evans/repository-dispatch@v4
+           uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
            with:
               token: ${{ secrets.API_TOKEN_GITHUB }}
               repository: infinispan/infinispan.github.io

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -12,14 +12,17 @@ on:
       - development
       - 16.0.x
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -60,7 +63,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
 
@@ -71,7 +74,7 @@ jobs:
           npm test
 
       - name: Test Logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: success() || failure()
         with:
           name: jdk17-test-results
@@ -83,4 +86,4 @@ jobs:
 
       - name: Dump docker logs on failure
         if: failure()
-        uses: jwalton/gh-docker-logs@v2
+        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2

--- a/.github/workflows/release-to-main.yml
+++ b/.github/workflows/release-to-main.yml
@@ -9,12 +9,17 @@ on:
         default: 'false'
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   merge-to-main:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add explicit top-level `permissions` blocks to all 4 workflow files, defaulting to `contents: read` with elevated scopes only where needed
- Pin every external action reference to immutable 40-char commit SHAs with trailing version comments, preventing supply-chain attacks via mutable tag/branch references

Fixes #709

Created with the assistance of an AI tool